### PR TITLE
fix(lib): fixes a bug in build config that would miss project config

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const readPkg = require('./read-pkg.js')
+const object = require('./lang/object/index.js')
 const parsePkgName = require('./parse-pkg-name.js')
 
 module.exports = buildConfig
@@ -12,7 +13,6 @@ async function buildConfig(build_id, config, context) {
   , tags = ['latest', '{major}-latest', '{version}']
   , args = {}
   , registry = null
-  , project
   , image
   } = config
 
@@ -33,7 +33,7 @@ async function buildConfig(build_id, config, context) {
   , nocache
   , name: image || name
   , build: build_id
-  , project: project === null ? project : scope
+  , project: object.has(config, 'project') ? config.project : scope
   , context: config.context || '.'
   }
 }

--- a/lib/lang/object/has.js
+++ b/lib/lang/object/has.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = hasProperty
+
+function hasProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop)
+}

--- a/lib/lang/object/index.js
+++ b/lib/lang/object/index.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   get: require('./get.js')
+, has: require('./has.js')
 }

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -53,6 +53,27 @@ test('build-config', async (t) => {
 
     {
       const config = await buildConfig('id', {
+        project: 'kittens'
+      , image: 'override'
+      , dockerfile: 'Dockerfile.test'
+      }, {
+        cwd: path.join(t.testdirName, 'scoped')
+      })
+      tt.deepEqual(config, {
+        dockerfile: 'Dockerfile.test'
+      , nocache: false
+      , tags: ['latest', '{major}-latest', '{version}']
+      , args: {}
+      , registry: null
+      , name: 'override'
+      , project: 'kittens'
+      , build: 'id'
+      , context: '.'
+      })
+    }
+
+    {
+      const config = await buildConfig('id', {
         project: null
       , image: 'override'
       , dockerfile: 'Dockerfile.test'


### PR DESCRIPTION
This adds a check for the presense of the project config option rather
that if it is explicitly null. This allows it to be omitted to allow
other values through while being able to set it

Semver: patch