### PR TITLE
BREAKING: scope the config options under `docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ omitted, it is assumed the docker daemon is already authenticated with the targe
 
 ### Options
 
-| Option         | Description                                                                                                                                 | Default
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------
-| tags           | _Optional_. An array of strings allowing to specify additional tags to apply to the image.                                                  | [`latest`, `{major}-latest`, `{version}`] |
-| image          | _Optional_. The name of the image to release.                                                                                               | Parsed from package.json `name` property
-| registry       | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port | `null` (dockerhub)
-| project        | _Optional_. The project or repository name to publish the image to                                                                          | For scoped packages, the scope will be used, otherwise `null`
-| dockerfile     | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                    | `Dockerfile`
-| context        | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                        | `.`
+| Option                | Description                                                                                                                                 | Default
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------
+| docker.tags           | _Optional_. An array of strings allowing to specify additional tags to apply to the image.                                                  | [`latest`, `{major}-latest`, `{version}`] |
+| docker.image          | _Optional_. The name of the image to release.                                                                                               | Parsed from package.json `name` property
+| docker.registry       | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port | `null` (dockerhub)
+| docker.project        | _Optional_. The project or repository name to publish the image to                                                                          | For scoped packages, the scope will be used, otherwise `null`
+| docker.dockerfile     | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                    | `Dockerfile`
+| docker.context        | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                        | `.`
 
 ## Usage
 
@@ -60,12 +60,14 @@ full configuration:
   "release": {
     "plugins": [
       ["@codedependant/semantic-release-docker", {
-        "path": "@codedependant/semantic-release-docker",
-        "tags": ["{version}", "{major}", "{major}.{minor}"],
-        "image": "my-image",
-        "dockerfile": "Dockerfile",
-        "registry": "quay.io",
-        "project": "codedependant"
+        "docker": {
+          "path": "@codedependant/semantic-release-docker",
+          "tags": ["{version}", "{major}", "{major}.{minor}"],
+          "image": "my-image",
+          "dockerfile": "Dockerfile",
+          "registry": "quay.io",
+          "project": "codedependant"
+        }
       }]
     ]
   }
@@ -73,6 +75,23 @@ full configuration:
 ```
 
 results in `quay.io/codedependant/my-image` with tags `1.0.0`, `1` and the `1.0` determined by `semantic-release`.
+
+Alternatively, using global options w/ root configuration
+```json
+{
+  "release": {
+    "extendds": "@internal/release-config-example",
+    "docker": {
+      "path": "@codedependant/semantic-release-docker",
+      "tags": ["{version}", "{major}", "{major}.{minor}"],
+      "image": "my-image",
+      "dockerfile": "Dockerfile",
+      "registry": "quay.io",
+      "project": "codedependant"
+    }
+  }
+}
+```
 
 minimum configuration:
 

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -14,7 +14,7 @@ async function buildConfig(build_id, config, context) {
   , args = {}
   , registry = null
   , image
-  } = config
+  } = (object.get(config, 'docker') || {})
 
   let name = null
   let scope = null
@@ -33,7 +33,7 @@ async function buildConfig(build_id, config, context) {
   , nocache
   , name: image || name
   , build: build_id
-  , project: object.has(config, 'project') ? config.project : scope
+  , project: object.has(config.docker, 'project') ? config.docker.project : scope
   , context: config.context || '.'
   }
 }

--- a/lib/lang/object/has.js
+++ b/lib/lang/object/has.js
@@ -3,5 +3,6 @@
 module.exports = hasProperty
 
 function hasProperty(obj, prop) {
+  if (!obj) return false
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }

--- a/test/integration/prepare.js
+++ b/test/integration/prepare.js
@@ -28,11 +28,13 @@ test('steps::prepare', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
-    , project: 'docker-prepare'
-    , image: 'fake'
-    , args: {MY_VARIABLE: '1'}
-    , dockerfile: 'docker/Dockerfile.prepare'
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      , project: 'docker-prepare'
+      , image: 'fake'
+      , args: {MY_VARIABLE: '1'}
+      , dockerfile: 'docker/Dockerfile.prepare'
+      }
     }, context)
 
     const auth = await verify(config, context)

--- a/test/integration/publish.js
+++ b/test/integration/publish.js
@@ -31,11 +31,13 @@ test('steps::publish', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
-    , project: 'docker-publish'
-    , image: 'real'
-    , tags: ['{previous.major}-previous', '{major}-foobar', '{version}']
-    , dockerfile: 'docker/Dockerfile.publish'
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      , project: 'docker-publish'
+      , image: 'real'
+      , tags: ['{previous.major}-previous', '{major}-foobar', '{version}']
+      , dockerfile: 'docker/Dockerfile.publish'
+      }
     }, context)
 
     const auth = await verify(config, context)

--- a/test/integration/verify.js
+++ b/test/integration/verify.js
@@ -70,7 +70,9 @@ test('steps::verify', async (t) => {
       }
     }
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      }
     }, context)
     tt.resolves(verify(config, context))
   })
@@ -89,7 +91,9 @@ test('steps::verify', async (t) => {
       }
     }
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      }
     }, context)
     tt.resolves(verify(config, context))
   })
@@ -147,7 +151,9 @@ test('steps::verify', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      }
     }, context)
     tt.rejects(verify(config, context), {
       code: 'EINVAL'
@@ -169,8 +175,10 @@ test('steps::verify', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      registry: DOCKER_REGISTRY_HOST
-    , dockerfile: 'Notafile'
+      docker: {
+        registry: DOCKER_REGISTRY_HOST
+      , dockerfile: 'Notafile'
+      }
     }, context)
 
     await tt.rejects(verify(config, context), {

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -53,9 +53,11 @@ test('build-config', async (t) => {
 
     {
       const config = await buildConfig('id', {
-        project: 'kittens'
-      , image: 'override'
-      , dockerfile: 'Dockerfile.test'
+        docker: {
+          project: 'kittens'
+        , image: 'override'
+        , dockerfile: 'Dockerfile.test'
+        }
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
@@ -74,9 +76,11 @@ test('build-config', async (t) => {
 
     {
       const config = await buildConfig('id', {
-        project: null
-      , image: 'override'
-      , dockerfile: 'Dockerfile.test'
+        docker: {
+          project: null
+        , image: 'override'
+        , dockerfile: 'Dockerfile.test'
+        }
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })


### PR DESCRIPTION
Scope the config options under a docker key to allow for less change of
a collision. This makes it easier to package in sharable config by
allowing the options to be defined at the root rather than at the plugin
level

Semver: major