### PR TITLE
feat(config)!: unnest config values from docker property 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install
-        run: npx pnpm install --frozen-lockfile
+        run: npm install
 
       - name: test
         run: npm test
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npx pnpm install --frozen-lockfile
+      - run: npm install
 
       - name: Publish
         run: npm run release

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+*.vim

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 hoist=true
+lock-file=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # 0000-BASE
 FROM docker:latest
 ARG SRC_DIR='.'
-RUN apk update && apk upgrade && apk add nodejs npm
+RUN apk update && apk upgrade && apk add nodejs npm git
 WORKDIR /opt/app
 COPY ${SRC_DIR}/package.json /opt/app/
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -44,55 +44,115 @@ omitted, it is assumed the docker daemon is already authenticated with the targe
 
 | Option                | Description                                                                                                                                 | Default
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------
-| docker.tags           | _Optional_. An array of strings allowing to specify additional tags to apply to the image.                                                  | [`latest`, `{major}-latest`, `{version}`] |
-| docker.image          | _Optional_. The name of the image to release.                                                                                               | Parsed from package.json `name` property
-| docker.registry       | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port | `null` (dockerhub)
-| docker.project        | _Optional_. The project or repository name to publish the image to                                                                          | For scoped packages, the scope will be used, otherwise `null`
-| docker.dockerfile     | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                    | `Dockerfile`
-| docker.context        | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                        | `.`
-| docker.login          | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                 | `true`
+| `dockerTags`          | _Optional_. An array of strings allowing to specify additional tags to apply to the image. Supports templating                              | [`latest`, `{major}-latest`, `{version}`]                     |
+| `dockerImage`         | _Optional_. The name of the image to release.                                                                                               | Parsed from package.json `name` property                      |
+| `dockerRegistry`      | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port | `null` (dockerhub)                                            |
+| `dockerProject`       | _Optional_. The project or repository name to publish the image to                                                                          | For scoped packages, the scope will be used, otherwise `null` |
+| `dockerDockerfile`    | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                    | `Dockerfile`                                                  |
+| `dockerContext`       | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                        | `.`                                                           |
+| `dockerLogin`         | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                 | `true`                                                        |
+| `dockerArgs`          | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                         |                                                               |
+| `dockerPublish`       | _Optional_. Automatically push image tags during the publish phase.                                                                         | `true`                                                        |
+
+### Build Arguments
+
+By default several build arguments will be included when the docker images is being built.
+Build arguments can be templated in the same fashion as docker tags. If the value for a
+build argument is explictly `true`, the value will be omitted and the value from
+a matching environment variable will be utilized instead. This can be usefule when trying to include
+secrets and other sensitive information
+
+| Argument Name       | Description                                                                                | Default                      |
+|---------------------|--------------------------------------------------------------------------------------------|------------------------------|
+| `SRC_DIRECTORY`     | The of the directory the build was triggered from                                          | The directory name of CWD    |
+| `TARGET_PATH`       | Path relative to the execution root. Usefule for Sharing a Single Docker file in monorepos |                              |
+| `NPM_PACKAGE_NAME`  | The `name` property extracted from `package.json` - if present                             |                              |
+| `NPM_PACKAGE_SCOPE` | The parsed scope from the `name` property from `package.json` - sans `@`                   |                              |
+| `CONFIG_NAME`       | The configured name of the docker image.                                                   | The parsed package name      |
+| `CONFIG_PROJECT`    | The configured docker repo project name                                                    | The package scope if present |
+| `GIT_SHA`           | The commit SHA of the current release                                                      |                              |
+| `GIT_TAG`           | The git tag of the current release                                                         |                              |
+
+### Template Variables
+
+String template will be passed these
+
+| Variable name  | Description                                                        | Type     |
+|----------------|--------------------------------------------------------------------|----------|
+| `git_sha`      | The commit SHA of the current release                              | `String` |
+| `git_tag`      | The git tag of the current release                                 | `String` |
+| `release_type` | The severity type of the current build (`major`, `minor`, `patch`) | `String` |
+| `relase_notes` | The release notes blob associated with the release                 | `String` |
+| `next`         | Semver object representing the next release                        | `Object` |
+| `previous`     | Semver object representing the previous release                    | `Object` |
+| `major`        | The major version of the next release                              | `Number` |
+| `minor`        | The minor version of the next release                              | `Number` |
+| `patch`        | The patch version of the next release                              | `Number` |
+| `env`          | Environment variables that were set at build time                  | `Object` |
+| `pkg`          | Values parsed from `package.json`                                  | `Object` |
+| `build`        | A Random build hash representing the current execution context     | `String` |
+| `now`          | Current timestamp is ISO 8601 format                               | `String` |
 
 ## Usage
 
-full configuration:
+**full configuration**:
 
-```json
-{
-  "release": {
-    "plugins": [
-      ["@codedependant/semantic-release-docker", {
-        "docker": {
-          "tags": ["latest", "{version}", "{major}-latest", "{major}.{minor}"],
-          "image": "my-image",
-          "dockerfile": "Dockerfile",
-          "registry": "quay.io",
-          "project": "codedependant"
-        }
-      }]
-    ]
-  }
+```javascript
+// release.config.js
+
+module.exports = {
+  branches: ['main']
+  plugins: [
+    ['@codedependant/semantic-release-docker', {
+      dockerTags: ['latest', '{version}', '{major}-latest', '{major}.{minor}'],
+      dockerImage: 'my-image',
+      dockerFile: 'Dockerfile',
+      dockerRegistry: 'quay.io',
+      dockerProject: 'codedependant',
+      dockerArgs: {
+        API_TOKEN: true
+      , RELEASE_DATE: new Date().toISOString()
+      , RELEASE_VERSION: '{next.version}'
+      }
+    }]
+  ]
 }
 ```
 
 results in `quay.io/codedependant/my-image` with tags `latest`, `1.0.0`, `1-latest` and the `1.0` determined by `semantic-release`.
 
 Alternatively, using global options w/ root configuration
-```json
+```json5
+// package.json
 {
+  "name": "@codedependant/test-project"
+  "version": "1.0.0"
   "release": {
-    "extends": "@internal/release-config-example",
-    "docker": {
-      "tags": ["latest", "{version}", "{major}-latest", "{major}.{minor}"],
-      "image": "my-image",
-      "dockerfile": "Dockerfile",
-      "registry": "quay.io",
-      "project": "codedependant"
+    "extends": "@internal/release-config-docker",
+    "dockerTags": ["latest", "{version}", "{major}-latest", "{major}.{minor}"],
+    "dockerImage": "my-image",
+    "dockerFile": "Dockerfile",
+    "dockerRegistry": "quay.io",
+    "dockerArgs": {
+      "GITHUB_TOKEN": true
+    , "SOME_VALUE": '{git_sha}'
     }
   }
 }
 ```
 
-minimum configuration:
+This would generate the following for a `1.2.0` build
+
+```shell
+$ docker build -t quay.io/codedependant/my-image --build-arg GITHUB_TOKEN --build-arg SOME_VALUE=6eada70 -f Dockerfile .
+$ docker tag <SHA1> latest
+$ docker tag <SHA1> 1.2.0
+$ docker tag <SHA1> 1.2
+$ docker tag <SHA1> 1-latest
+$ docker push quay.io/codedependant/my-image
+```
+
+**minimum configuration**:
 
 ```json
 {
@@ -104,14 +164,14 @@ minimum configuration:
 }
 ```
 
-* A package name `@codedependant/test-project` results in `codedependant/test-project`
-* A package name `test-project` results in `test-project`
+* A package name `@codedependant/test-project` results in docker project name`codedependant` and image name `test-project`
+* A package name `test-project` results in a docker image name `test-project`
 
 the default docker image tags for the 1.0.0 release would be `1.0.0`, `1-latest`, `latest`
 
 ## Development
 
-#### Docker Registry
+### Docker Registry
 
 To be able to push to the local registry with auth credentials, ssl certificates are required.
 This project uses self signed certs. To regenerate the certs run the following:

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = {
 , buildConfig
 }
 
-
 async function prepare(config, context) {
   return dockerPrepare(await buildConfig(build_id, config, context), context)
 }

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -10,14 +10,15 @@ module.exports = buildConfig
 
 async function buildConfig(build_id, config, context) {
   const {
-    dockerfile = 'Dockerfile'
-  , nocache = false
-  , tags = ['latest', '{major}-latest', '{version}']
-  , args = {}
-  , registry = null
-  , login = true
-  , image
-  } = (object.get(config, 'docker') || {})
+    dockerFile: dockerfile = 'Dockerfile'
+  , dockerNoCache: nocache = false
+  , dockerTags: tags = ['latest', '{major}-latest', '{version}']
+  , dockerArgs: args = {}
+  , dockerRegistry: registry = null
+  , dockerLogin: login = true
+  , dockerImage: image
+  , dockerPublish: publish = true
+  } = config
 
   let name = null
   let scope = null
@@ -29,7 +30,7 @@ async function buildConfig(build_id, config, context) {
     scope = parsed.scope
   } catch (_) {}
 
-  const project = object.has(config.docker, 'project') ? config.docker.project : scope
+  const project = object.has(config, 'dockerProject') ? config.dockerProject : scope
   const root = object.get(context, 'options.root')
   const target = path.relative(root || context.cwd, context.cwd) || PWD
   const {nextRelease = {}} = context
@@ -40,6 +41,7 @@ async function buildConfig(build_id, config, context) {
   , nocache
   , pkg
   , project
+  , publish
   , args: {
       SRC_DIRECTORY: path.basename(context.cwd)
     , TARGET_PATH: target

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -32,7 +32,7 @@ async function buildConfig(build_id, config, context) {
   const project = object.has(config.docker, 'project') ? config.docker.project : scope
   const root = object.get(context, 'options.root')
   const target = path.relative(root || context.cwd, context.cwd) || PWD
-
+  const {nextRelease = {}} = context
   return {
     tags
   , registry
@@ -47,11 +47,14 @@ async function buildConfig(build_id, config, context) {
     , NPM_PACKAGE_SCOPE: scope
     , CONFIG_NAME: image || name
     , CONFIG_PROJECT: project
-    , ...args
+    , GIT_SHA: nextRelease.gitHead || ''
+    , GIT_TAG: nextRelease.gitTag || ''
+    , ...(args || {})
     }
   , name: image || name
   , build: build_id
   , login: login
+  , env: context.env
   , context: config.context || '.'
   }
 }

--- a/lib/build-template-vars.js
+++ b/lib/build-template-vars.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const semver = require('semver')
+const now = new Date().toISOString()
 
 module.exports = buildTemplateVars
 
-function buildTemplateVars(context, opts) {
+function buildTemplateVars(opts, context) {
   const {nextRelease = {}, lastRelease = {}} = context
 
   const versions = {
@@ -22,5 +23,6 @@ function buildTemplateVars(context, opts) {
   , git_sha: nextRelease.gitHead
   , release_type: nextRelease.type
   , release_notes: nextRelease.notes
+  , now: now
   }
 }

--- a/lib/build-template-vars.js
+++ b/lib/build-template-vars.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const semver = require('semver')
+
+module.exports = buildTemplateVars
+
+function buildTemplateVars(context, opts) {
+  const {nextRelease = {}, lastRelease = {}} = context
+
+  const versions = {
+    next: semver.parse(nextRelease.version) || {}
+  , previous: semver.parse(lastRelease.version) || {}
+  }
+
+  const {tags: _, ...rest} = opts
+  return {
+    ...versions.next
+  , ...versions
+  , ...nextRelease
+  , ...rest
+  , git_tag: nextRelease.gitTag
+  , git_sha: nextRelease.gitHead
+  , release_type: nextRelease.type
+  , release_notes: nextRelease.notes
+  }
+}

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -72,7 +72,7 @@ class Image {
   get build_cmd() {
     const args = []
     for (const [name, value] of this.opts.args.entries()) {
-      if (value === true) {
+      if (value === true || value == null) { // eslint-disable-line no-eq-null
         args.push('--build-arg', name)
       } else {
         args.push('--build-arg', `${name}=${value}`)

--- a/lib/lang/string/template.js
+++ b/lib/lang/string/template.js
@@ -5,6 +5,7 @@ module.exports = template
 
 function template(str) {
   return function interpolate(values) {
+    if (typeof str !== 'string') return str
     return str.replace(/{([^{}]*)}/g, function(original, parsed) {
       const result = object.get(values, parsed)
       return typeof result === 'string' || typeof result === 'number' ? result : original

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const debug = require('debug')('semantic-release:semantic-release-docker:prepare')
 const docker = require('./docker/index.js')
+const buildTemplateVars = require('./build-template-vars.js')
 
 module.exports = dockerPrepare
 
@@ -20,7 +21,10 @@ async function dockerPrepare(opts, context) {
   const args = {
     ...opts.args
   }
+
   if (args) {
+    const vars = buildTemplateVars(context, opts)
+    debug('template variables', vars)
     for (const [key, value] of Object.entries(args)) {
       image.arg(key, value)
     }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const path = require('path')
-const debug = require('debug')('semantic-release:semantic-release-docker:prepare')
 const docker = require('./docker/index.js')
 const buildTemplateVars = require('./build-template-vars.js')
+const string = require('./lang/string/index.js')
 
 module.exports = dockerPrepare
 
@@ -22,16 +22,13 @@ async function dockerPrepare(opts, context) {
     ...opts.args
   }
 
-  if (args) {
-    const vars = buildTemplateVars(context, opts)
-    debug('template variables', vars)
-    for (const [key, value] of Object.entries(args)) {
-      image.arg(key, value)
-    }
+  const vars = buildTemplateVars(opts, context)
+  for (const [key, value] of Object.entries(args)) {
+    image.arg(key, string.template(value)(vars))
   }
 
   context.logger.info('building image', image.name)
-  debug('build command', image.build_cmd)
+  context.logger.debug('build command: docker %s', image.build_cmd.join(' '))
   await image.build(path.join(cwd, opts.context))
   return image
 }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,18 +1,13 @@
 'use strict'
 
-const semver = require('semver')
+const buildTemplateVars = require('./build-template-vars.js')
 const docker = require('./docker/index.js')
 const string = require('./lang/string/index.js')
 
 module.exports = publish
 
 async function publish(opts, context) {
-  const {lastRelease, nextRelease, cwd, logger} = context
-  const versions = {
-    next: semver.parse(nextRelease.version)
-  , previous: semver.parse(lastRelease.version)
-  }
-
+  const {cwd, logger} = context
   const image = new docker.Image({
     registry: opts.registry
   , project: opts.project
@@ -22,18 +17,14 @@ async function publish(opts, context) {
   , cwd: cwd
   })
 
-  const vars = {
-    ...versions.next
-  , ...versions
-  }
-
+  const vars = buildTemplateVars(context, opts)
   const tags = opts.tags.map((template) => {
     return string.template(template)(vars)
-  })
+  }).filter(Boolean)
 
   logger.info('tagging docker image', image.id)
   for (const tag of tags) {
-    console.log(`pushing image: ${image.repo} tag: ${tag}`)
+    logger.info(`pushing image: ${image.repo} tag: ${tag}`)
     await image.tag(tag)
   }
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -17,7 +17,7 @@ async function publish(opts, context) {
   , cwd: cwd
   })
 
-  const vars = buildTemplateVars(context, opts)
+  const vars = buildTemplateVars(opts, context)
   const tags = opts.tags.map((template) => {
     return string.template(template)(vars)
   }).filter(Boolean)
@@ -25,7 +25,7 @@ async function publish(opts, context) {
   logger.info('tagging docker image', image.id)
   for (const tag of tags) {
     logger.info(`pushing image: ${image.repo} tag: ${tag}`)
-    await image.tag(tag)
+    await image.tag(tag, opts.publish)
   }
 
   await image.clean()

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -39,8 +39,8 @@ async function verify(opts, context) {
     const error = new SemanticError(
       `Unable to locate Dockerfile: ${image.dockerfile}`
     , err.code
-    , 'Docker file is read from a local relative to PWD. Make sure the "dockerfile" option'
-        + ' is set to the desired location'
+    , 'Docker file is read from a local relative to PWD. Make sure the "dockerfile"'
+        + ' option is set to the desired location'
     )
 
     throw error

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "eslintConfig": {
     "root": true,
-    "extends": "@esatterwhite/eslint-config-reasonable",
+    "extends": "codedependant",
     "ignorePatterns": [
       "node_modules/",
       "test/fixture/",
@@ -79,11 +79,11 @@
     ]
   },
   "devDependencies": {
-    "@esatterwhite/eslint-config-reasonable": "^1.0.2",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.0.7",
     "eslint": "^7.4.0",
+    "eslint-config-codedependant": "^2.1.6",
     "sinon": "^9.0.2",
     "tap": "^14.10.7"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     ],
     "nyc-arg": [
       "--exclude=coverage/",
-      "--exclude=test/"
+      "--exclude=test/",
+      "--all"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     ]
   },
   "devDependencies": {
+    "@codedependant/release-config-npm": "^1.0.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.0.7",

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,6 @@
 'use strict'
 
+/* istanbul ignore file */
 module.exports = {
   branches: [
     'master'

--- a/release.config.js
+++ b/release.config.js
@@ -2,43 +2,8 @@
 
 /* istanbul ignore file */
 module.exports = {
-  branches: [
-    'master'
-  ]
-, plugins: [
-    ['@semantic-release/commit-analyzer', {
-      parserOpts: {
-        noteKeywords: ['BREAKING', 'BREAKING CHANGE', 'BREAKING CHANGES']
-      , referenceActions: [
-          'close', 'closes', 'closed'
-        , 'fix', 'fixes', 'fixed'
-        , 'resolve', 'resolves', 'resolved'
-        ]
-      }
-    , releaseRules: [
-        {type: 'build', release: 'patch'}
-      , {type: 'ci', release: 'patch'}
-      , {type: 'release', release: 'patch'}
-      , {type: 'chore', release: 'patch'}
-      , {type: 'refactor', release: 'patch'}
-      , {type: 'test', release: 'patch'}
-      , {type: 'doc', release: 'patch'}
-      , {type: 'lib', release: 'patch'}
-      ]
-    }],
-  , ['@semantic-release/release-notes-generator', null]
-  , ['@semantic-release/changelog', {
-      changelogFile: 'CHANGELOG.md'
-    , changelogTitle: '# Semantic Release Docker'
-    }]
-  , ['@semantic-release/npm', null]
-  , ['@semantic-release/git', {
-      assets: [
-        'package.json'
-      , 'pnpm-lock.yaml'
-      , 'CHANGELOG.md'
-      ]
-    }]
-  , ['@semantic-release/github', null]
-  ]
+  branches: ['master']
+, extends: '@codedependant/release-config-npm'
+, changelogFile: 'CHANGELOG.md'
+, changelogTitle: '# Semantic Release Docker'
 }

--- a/test/common/git/add.js
+++ b/test/common/git/add.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const execa = require('execa')
+
+module.exports = add
+
+async function add(cwd, file = '.') {
+  await execa('git', ['add', file], {cwd: cwd})
+}

--- a/test/common/git/commit.js
+++ b/test/common/git/commit.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const execa = require('execa')
+const head = require('./head.js')
+
+module.exports = commit
+
+async function commit(cwd, message) {
+  await execa('git', ['commit', '-m', message], {cwd: cwd})
+  return head(cwd)
+}

--- a/test/common/git/head.js
+++ b/test/common/git/head.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const execa = require('execa')
+
+module.exports = head
+
+async function head(cwd) {
+  const {stdout} = await execa('git', ['rev-parse', 'HEAD'], {cwd: cwd})
+  return stdout
+}

--- a/test/common/git/index.js
+++ b/test/common/git/index.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  add: require('./add.js')
+, commit: require('./commit.js')
+, head: require('./head.js')
+, initOrigin: require('./init-origin.js')
+, initRemote: require('./init-remote.js')
+, init: require('./init.js')
+, push: require('./push.js')
+, tag: require('./tag.js')
+, tags: require('./tags.js')
+}

--- a/test/common/git/init-origin.js
+++ b/test/common/git/init-origin.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const execa = require('execa')
+const initRemote = require('./init-remote.js')
+
+module.exports = initOrigin
+
+async function initOrigin(cwd) {
+  const origin = await initRemote()
+  await execa('git', ['remote', 'add', 'origin', origin], {cwd: cwd})
+  await execa('git', ['push', '--all', 'origin'], {cwd: cwd})
+  return origin
+}

--- a/test/common/git/init-remote.js
+++ b/test/common/git/init-remote.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const path = require('path')
+const os = require('os')
+const {promises: fs} = require('fs')
+const execa = require('execa')
+
+module.exports = initRemote
+
+async function initRemote(branch = 'main') {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), path.sep))
+  await execa('git', [
+    'init', '--bare', `--initial-branch=${branch}`
+  ], {cwd: cwd})
+  return `file://${cwd}`
+}

--- a/test/common/git/init.js
+++ b/test/common/git/init.js
@@ -9,10 +9,12 @@ module.exports = init
 
 async function init(dir, branch = 'main') {
   const cwd = dir || await fs.mkdtemp(path.join(os.tmpdir(), path.sep))
-  await execa('git', ['init'], {cwd: cwd})
+  await execa('git', ['init', cwd])
   await execa('git', ['checkout', '-b', branch], {cwd: cwd})
   await execa('git', ['config', '--add', 'commit.gpgsign', false])
-  await execa('git', ['config', '--add', 'pull.default', 'current'])
-  await execa('git', ['config', '--add', 'push.default', 'current'])
+  await execa('git', ['config', '--add', 'pull.default', 'current'], {cwd})
+  await execa('git', ['config', '--add', 'push.default', 'current'], {cwd})
+  await execa('git', ['config', '--add', 'user.name', 'secretsquirrel'], {cwd})
+  await execa('git', ['config', '--add', 'user.email', 'secret@mail.com'], {cwd})
   return cwd
 }

--- a/test/common/git/init.js
+++ b/test/common/git/init.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const path = require('path')
+const os = require('os')
+const {promises: fs} = require('fs')
+const execa = require('execa')
+
+module.exports = init
+
+async function init(dir, branch = 'main') {
+  const cwd = dir || await fs.mkdtemp(path.join(os.tmpdir(), path.sep))
+  await execa('git', ['init'], {cwd: cwd})
+  await execa('git', ['checkout', '-b', branch], {cwd: cwd})
+  await execa('git', ['config', '--add', 'commit.gpgsign', false])
+  await execa('git', ['config', '--add', 'pull.default', 'current'])
+  await execa('git', ['config', '--add', 'push.default', 'current'])
+  return cwd
+}

--- a/test/common/git/push.js
+++ b/test/common/git/push.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const execa = require('execa')
+
+module.exports = push
+
+async function push(cwd, remote = 'origin', branch = 'main') {
+  await execa('git', ['push', '--tags', remote, `HEAD:${branch}`], {cwd: cwd})
+}

--- a/test/common/git/tag.js
+++ b/test/common/git/tag.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const execa = require('execa')
+
+module.exports = tag
+
+async function tag(cwd, name, hash) {
+  const args = hash
+    ? ['tag', '-f', name, hash]
+    : ['tag', name]
+
+  await execa('git', args, {cwd: cwd})
+}

--- a/test/common/git/tags.js
+++ b/test/common/git/tags.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const os = require('os')
+const execa = require('execa')
+
+module.exports = tags
+
+async function tags(cwd, hash) {
+  const cmd = hash
+    ? ['describe', '--tags', '--exact-match', hash]
+    : ['tag', '-l', '--sort', 'v:refname']
+  const {stdout} = await execa('git', cmd, {cwd: cwd})
+  return stdout.split(os.EOL).filter(Boolean)
+}

--- a/test/integration/prepare.js
+++ b/test/integration/prepare.js
@@ -10,6 +10,10 @@ const verify = require('../../lib/verify.js')
 const prepare = require('../../lib/prepare.js')
 const DOCKER_REGISTRY_HOST = process.env.TEST_DOCKER_REGISTRY || 'localhost:5000'
 const fixturedir = path.join(__dirname, '..', 'fixture')
+const DATE_REGEX = new RegExp(
+  '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}'
+    + '(\.[\\d]{1,6})?(Z|[\\+\\-][\\d]{2}:[\\d]{2})$' // eslint-disable-line no-useless-escape
+)
 
 test('steps::prepare', async (t) => {
   t.test('build image created', async (tt) => {
@@ -21,20 +25,30 @@ test('steps::prepare', async (t) => {
       , DOCKER_REGISTRY_PASSWORD: 'secretsquirrel'
       }
     , cwd: fixturedir
+    , nextRelease: {
+        version: '2.1.2'
+      , gitTag: 'v2.1.2'
+      , gitHead: 'abacadaba'
+      }
     , logger: {
         success: sinon.stub()
       , info: sinon.stub()
+      , debug: sinon.stub()
       }
     }
 
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      , project: 'docker-prepare'
-      , image: 'fake'
-      , args: {MY_VARIABLE: '1'}
-      , dockerfile: 'docker/Dockerfile.prepare'
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerProject: 'docker-prepare'
+    , dockerImage: 'fake'
+    , dockerArgs: {
+        MY_VARIABLE: '1'
+      , TAG_TEMPLATE: '{git_tag}'
+      , MAJOR_TEMPLATE: '{major}'
+      , GIT_REF: '{git_sha}'
+      , BUILD_DATE: '{now}'
       }
+    , dockerFile: 'docker/Dockerfile.prepare'
     }, context)
 
     const auth = await verify(config, context)
@@ -45,6 +59,11 @@ test('steps::prepare', async (t) => {
     tt.on('end', () => {
       image.clean()
     })
+
+    tt.equal(image.opts.args.get('TAG_TEMPLATE'), 'v2.1.2', 'TAG_TEMPLATE value')
+    tt.equal(image.opts.args.get('MAJOR_TEMPLATE'), '2', 'MAJOR_TEMPLATE value')
+    tt.equal(image.opts.args.get('GIT_REF'), 'abacadaba', 'GIT_REF value')
+    tt.match(image.opts.args.get('BUILD_DATE'), DATE_REGEX, 'BUILD_DATE value')
 
     const {stdout} = await execa('docker', [
       'images', image.name

--- a/test/integration/prepare.js
+++ b/test/integration/prepare.js
@@ -46,7 +46,10 @@ test('steps::prepare', async (t) => {
       image.clean()
     })
 
-    const {stdout} = await execa('docker', ['images', image.name, '-q', '--format={{ .Tag }}'])
+    const {stdout} = await execa('docker', [
+      'images', image.name
+    , '-q', '--format={{ .Tag }}'
+    ])
     tt.equal(stdout, build_id, 'build image fully built')
   })
 }).catch(threw)

--- a/test/integration/publish.js
+++ b/test/integration/publish.js
@@ -27,17 +27,16 @@ test('steps::publish', async (t) => {
     , logger: {
         success: sinon.stub()
       , info: sinon.stub()
+      , debug: sinon.stub()
       }
     }
 
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      , project: 'docker-publish'
-      , image: 'real'
-      , tags: ['{previous.major}-previous', '{major}-foobar', '{version}']
-      , dockerfile: 'docker/Dockerfile.publish'
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerProject: 'docker-publish'
+    , dockerImage: 'real'
+    , dockerTags: ['{previous.major}-previous', '{major}-foobar', '{version}']
+    , dockerFile: 'docker/Dockerfile.publish'
     }, context)
 
     const auth = await verify(config, context)

--- a/test/integration/release.js
+++ b/test/integration/release.js
@@ -1,0 +1,100 @@
+'use strict'
+
+const execa = require('execa')
+const {test, threw} = require('tap')
+const git = require('../common/git/index.js')
+
+const stringify = JSON.stringify
+
+test('docker release', async (t) => {
+  const cwd = t.testdir({
+    'package.json': stringify({
+      name: 'service-meta-package'
+    , version: '0.0.0-development'
+    , scripts: {
+        'test-release': 'semantic-release'
+      }
+    , release: {
+        ci: true
+      , npmPublish: false
+      , branches: ['main']
+      , docker: {
+          registry: 'localhost:5000'
+        , project: 'docker-release'
+        , image: 'fake'
+        , args: {
+            SAMPLE_THING: '{type}.{version}'
+          , GIT_REF: '{git_sha}-{git_tag}'
+          }
+        }
+      , plugins: [
+          '@semantic-release/commit-analyzer'
+        , '@semantic-release/release-notes-generator'
+        , '@semantic-release/npm'
+        , '@codedependant/semantic-release-docker'
+        ]
+      }
+    , devDependencies: {
+        'semantic-release': '*'
+      , '@semantic-release/commit-analyzer': '*'
+      , '@semantic-release/release-notes-generator': '*'
+      , '@semantic-release/npm': '*'
+      , '@codedependant/semantic-release-docker': 'file:../../../'
+      }
+    })
+  , Dockerfile: 'FROM debian:buster-slim\n\nRUN ls -alh'
+  , '.gitignore': 'node_modules/'
+  })
+
+  await git.init(cwd)
+  await git.add(cwd)
+  await git.commit(cwd, 'feat: initial release')
+
+  const origin = await git.initOrigin(cwd)
+  t.comment(`repository: ${cwd}`)
+  t.comment(`origin: ${origin}`)
+
+  {
+    const stream = execa('npm', [
+      'install'
+    ], {
+      cwd: cwd
+    , extendEnv: false
+    , env: {
+        BRANCH_NAME: 'main'
+      , CI_BRANCH: 'main'
+      , CI: 'true'
+      , GITHUB_REF: 'refs/heads/main'
+      , PWD: cwd
+      , DEBUG: process.env.DEBUG
+      , PATH: process.env.PATH
+      , HOME: process.env.HOME
+      , USER: process.env.USER
+      }
+    })
+
+    stream.stdout.pipe(process.stdout)
+    await stream
+  }
+
+  const stream = execa('npm', [
+    'run'
+  , 'test-release'
+  , `--repositoryUrl=${origin}`], {
+    cwd: cwd
+  , extendEnv: false
+  , env: {
+      BRANCH_NAME: 'main'
+    , CI_BRANCH: 'main'
+    , CI: 'true'
+    , GITHUB_REF: 'refs/heads/main'
+    , PWD: cwd
+    , DEBUG: process.env.DEBUG
+    , PATH: process.env.PATH
+    , HOME: process.env.HOME
+    , USER: process.env.USER
+    }
+  })
+  await stream
+
+}).catch(threw)

--- a/test/integration/verify.js
+++ b/test/integration/verify.js
@@ -70,9 +70,7 @@ test('steps::verify', async (t) => {
       }
     }
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
     }, context)
     tt.resolves(verify(config, context))
   })
@@ -91,9 +89,7 @@ test('steps::verify', async (t) => {
       }
     }
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
     }, context)
     tt.resolves(verify(config, context))
   })
@@ -111,10 +107,8 @@ test('steps::verify', async (t) => {
       }
     }
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      , login: false
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerLogin: false
     }, context)
     tt.resolves(verify(config, context))
   })
@@ -172,9 +166,7 @@ test('steps::verify', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
     }, context)
     tt.rejects(verify(config, context), {
       code: 'EINVAL'
@@ -199,10 +191,8 @@ test('steps::verify', async (t) => {
     }
 
     const config = await buildConfig(build_id, {
-      docker: {
-        registry: DOCKER_REGISTRY_HOST
-      , dockerfile: 'Notafile'
-      }
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerFile: 'Notafile'
     }, context)
 
     await tt.rejects(verify(config, context), {

--- a/test/integration/verify.js
+++ b/test/integration/verify.js
@@ -179,7 +179,10 @@ test('steps::verify', async (t) => {
     tt.rejects(verify(config, context), {
       code: 'EINVAL'
     , name: 'SemanticReleaseError'
-    , details: /image name parsed from package.json name if possible. or via the "image" option/gi
+    , details: new RegExp(
+        'image name parsed from package.json name if possible. or via the "image" option'
+      , 'gi'
+      )
     })
   })
 

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -26,6 +26,7 @@ test('build-config', async (t) => {
     })
     tt.match(config, {
       dockerfile: 'Dockerfile'
+    , publish: true
     , nocache: false
     , tags: ['latest', '{major}-latest', '{version}']
     , args: {
@@ -56,6 +57,7 @@ test('build-config', async (t) => {
     tt.match(config, {
       dockerfile: 'Dockerfile'
     , nocache: false
+    , publish: true
     , tags: ['latest', '{major}-latest', '{version}']
     , args: {
         SRC_DIRECTORY: 'one'
@@ -103,16 +105,16 @@ test('build-config', async (t) => {
 
     {
       const config = await buildConfig('id', {
-        docker: {
-          project: 'kittens'
-        , image: 'override'
-        , dockerfile: 'Dockerfile.test'
-        }
+        dockerProject: 'kittens'
+      , dockerImage: 'override'
+      , dockerFile: 'Dockerfile.test'
+      , dockerPublish: false
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
       tt.match(config, {
         dockerfile: 'Dockerfile.test'
+      , publish: false
       , nocache: false
       , tags: ['latest', '{major}-latest', '{version}']
       , args: {
@@ -134,11 +136,9 @@ test('build-config', async (t) => {
 
     {
       const config = await buildConfig('id', {
-        docker: {
-          project: null
-        , image: 'override'
-        , dockerfile: 'Dockerfile.test'
-        }
+        dockerProject: null
+      , dockerImage: 'override'
+      , dockerFile: 'Dockerfile.test'
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })

--- a/test/unit/build-template-vars.js
+++ b/test/unit/build-template-vars.js
@@ -21,16 +21,14 @@ test('buildTemplateVars', async (t) => {
     }
   }
   const opts = await buildConfig('abacadaba', {
-    docker: {
-      args: {
-        TEMPLATE_VALUE: '{type}.{version}'
-      , BOOLEAN_VALUE: true
-      , NULL_VALUE: null
-      }
+    dockerArgs: {
+      TEMPLATE_VALUE: '{type}.{version}'
+    , BOOLEAN_VALUE: true
+    , NULL_VALUE: null
     }
   }, context)
 
-  const vars = buildTemplateVars(context, opts)
+  const vars = buildTemplateVars(opts, context)
   t.match(vars, {
     release_type: 'major'
   , release_notes: 'test it'

--- a/test/unit/build-template-vars.js
+++ b/test/unit/build-template-vars.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const {test, threw} = require('tap')
+const buildConfig = require('../../lib/build-config.js')
+const buildTemplateVars = require('../../lib/build-template-vars.js')
+
+test('buildTemplateVars', async (t) => {
+  const cwd = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'template-vars'
+    })
+  })
+  const context = {
+    cwd
+  , nextRelease: {
+      version: '1.0.0'
+    , gitTag: 'v1.0.0'
+    , gitHead: 'abcdefgh'
+    , type: 'major'
+    , notes: 'test it'
+    }
+  }
+  const opts = await buildConfig('abacadaba', {
+    docker: {
+      args: {
+        TEMPLATE_VALUE: '{type}.{version}'
+      , BOOLEAN_VALUE: true
+      , NULL_VALUE: null
+      }
+    }
+  }, context)
+
+  const vars = buildTemplateVars(context, opts)
+  t.match(vars, {
+    release_type: 'major'
+  , release_notes: 'test it'
+  , version: '1.0.0'
+  , git_sha: 'abcdefgh'
+  , git_tag: 'v1.0.0'
+  , pkg: {name: 'template-vars'}
+  , major: 1
+  , minor: 0
+  , patch: 0
+  , version: '1.0.0'
+  , next: {
+      major: 1
+    , minor: 0
+    , patch: 0
+    , version: '1.0.0'
+    }
+  , args: {
+      SRC_DIRECTORY: String
+    , TARGET_PATH: String
+    , NPM_PACKAGE_NAME: 'template-vars'
+    , NPM_PACKAGE_SCOPE: null
+    , CONFIG_NAME: String
+    , CONFIG_PROJECT: null
+    , GIT_SHA: 'abcdefgh'
+    , GIT_TAG: 'v1.0.0'
+    , TEMPLATE_VALUE: '{type}.{version}'
+    , BOOLEAN_VALUE: true
+    , NULL_VALUE: null
+    }
+  }, 'expected template values')
+}).catch(threw)

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -218,7 +218,10 @@ test('Image', async (t) => {
     , context: path.join(__dirname, 'fixture')
     })
     await img.tag('1.0.0', false)
-    const {stdout} = await execa('docker', ['images', img.repo, '-q', '--format={{ .Tag }}'])
+    const {stdout} = await execa('docker', [
+      'images', img.repo
+    , '-q', '--format={{ .Tag }}'
+    ])
     const tags = stdout.split(os.EOL)
     tt.deepEqual(tags.sort(), [build_id, '1.0.0'].sort(), 'image tags')
   })
@@ -233,7 +236,10 @@ test('Image', async (t) => {
     , dockerfile: path.join('fixture', 'Dockerfile.test')
     })
     await img.clean()
-    const {stdout} = await execa('docker', ['images', img.repo, '-q', '--format={{ .Tag }}'])
+    const {stdout} = await execa('docker', [
+      'images', img.repo
+    , '-q', '--format={{ .Tag }}'
+    ])
     tt.deepEqual(stdout, '', 'all tags removed')
   })
 

--- a/test/unit/lang/object.js
+++ b/test/unit/lang/object.js
@@ -34,4 +34,12 @@ test('object', async (t) => {
     tt.strictEqual(object.get(obj, 'foo.bar.baz.test'), null, 'foo.bar.baz.test')
     tt.strictEqual(object.get(null, 'foo.bar.baz'), null, 'null input')
   })
+
+  t.test('has', async (t) => {
+    t.ok(object.has(obj, 'bar'), 'key found')
+    t.ok(object.has(obj, 'biff'), 'has key w/ null value')
+    t.false(object.has(obj, 'whizbang'), 'key not found')
+    t.false(object.has(undefined, 'whizbang'), 'undefined object')
+
+  })
 }).catch(threw)

--- a/test/unit/lang/string.js
+++ b/test/unit/lang/string.js
@@ -21,6 +21,11 @@ test('string', async (t) => {
       , values: {place: {name: 'boston'}}
       , expected: 'hello boston'
       , message: 'nested values'
+      }, {
+        input: null
+      , values: {place: {name: 'boston'}}
+      , expected: null
+      , message: 'non string value returns value'
       }
     ]
 


### PR DESCRIPTION
Flatten the docker config option for semantic release into the root
config. Semantic release doesn't do a very good job of merging options
that are coming from a sharable configuration. This makes it easier to
utilize overrides when using a sharable config. Options are camel cased
using the docker root word prefix

`docker.args` -> `dockerArgs`
`docker.login` -> `dockerLogin`

BREAKING CHANGES: flatten the docker config object in to root level options

- - -

allows docker build arguments to be treated as a string template