### PR TITLE
fix(docker): honor absolute paths to docker file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: Test + Release
 on:
   pull_request:
     branches:
-      - master
+      - main
 
   push:
     branch:
-      - master
+      - main
 jobs:
   test:
     name: Test Suite

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -62,8 +62,9 @@ class Image {
   }
 
   get dockerfile() {
-    return path.join(this.opts.cwd, this.opts.dockerfile)
+    return path.resolve(this.opts.cwd, this.opts.dockerfile)
   }
+
   arg(key, val) {
     this.opts.args.set(key, val)
     return this
@@ -82,7 +83,7 @@ class Image {
       'build'
     , '--quiet'
     , '--tag'
-    , `${this.name}`
+    , this.name
     , ...args
     , '-f'
     , this.dockerfile

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@
 
 /* istanbul ignore file */
 module.exports = {
-  branches: ['master']
+  branches: ['main']
 , extends: '@codedependant/release-config-npm'
 , changelogFile: 'CHANGELOG.md'
 , changelogTitle: '# Semantic Release Docker'

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -63,6 +63,49 @@ test('Image', async (t) => {
     tt.equal(img.context, '.', 'default image context')
     img.context = __dirname
     tt.equal(img.context, __dirname, 'context override')
+    tt.equal(
+      img.dockerfile
+    , path.join(__dirname, 'build', 'Dockerfile.test')
+    , 'docker file path'
+    )
+  })
+
+  t.test('dockerfile location resolution', async (t) => {
+    t.test('relative location', async (t) => {
+      const img = new docker.Image({
+        name: 'test'
+      , build_id: 'abc123'
+      , registry: 'quay.io'
+      , project: 'esatterwhite'
+      , name: 'test'
+      , dockerfile: '../../Dockerfile.test'
+      , cwd: path.join(__dirname, 'build')
+      , sha: 'hello'
+      })
+      t.equal(
+        img.dockerfile
+      , path.join(__dirname, '..', 'Dockerfile.test')
+      , 'docker file path'
+      )
+    })
+
+    t.test('absolute path', async (t) => {
+      const img = new docker.Image({
+        name: 'test'
+      , build_id: 'abc123'
+      , registry: 'quay.io'
+      , project: 'esatterwhite'
+      , name: 'test'
+      , dockerfile: '/var/opt/Dockerfile.test'
+      , cwd: path.join(__dirname, 'build')
+      , sha: 'hello'
+      })
+      t.equal(
+        img.dockerfile
+      , '/var/opt/Dockerfile.test'
+      , 'docker file path'
+      )
+    })
   })
 
   t.test('image#id()', async (tt) => {


### PR DESCRIPTION
if the configured docker file option is an absolute path, it should be
used as. Previously this operation used path.join which does not respect
absolute paths. This fix makes used of path.resolve which will use an
absolute path if provided, else resolve the relative location