### PR TITLE
feat(lib): parse tags array from string

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const readPkg = require('./read-pkg.js')
 const object = require('./lang/object/index.js')
+const array = require('./lang/array/index.js')
 const parsePkgName = require('./parse-pkg-name.js')
 const PWD = '.'
 
@@ -35,13 +36,13 @@ async function buildConfig(build_id, config, context) {
   const target = path.relative(root || context.cwd, context.cwd) || PWD
   const {nextRelease = {}} = context
   return {
-    tags
-  , registry
+    registry
   , dockerfile
   , nocache
   , pkg
   , project
   , publish
+  , tags: array.toArray(tags)
   , args: {
       SRC_DIRECTORY: path.basename(context.cwd)
     , TARGET_PATH: target

--- a/lib/lang/array/index.js
+++ b/lib/lang/array/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  toArray: require('./to-array.js')
+}

--- a/lib/lang/array/to-array.js
+++ b/lib/lang/array/to-array.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const CSV_SEP_EXP = /\s*,\s*/
+module.exports = function toArray(item, sep = CSV_SEP_EXP) {
+  if (!item) return []
+  if (item instanceof Set) return Array.from(item)
+  if (Array.isArray(item)) return item
+  return typeof item === 'string' ? item.split(sep) : [item]
+}

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -139,13 +139,14 @@ test('build-config', async (t) => {
         dockerProject: null
       , dockerImage: 'override'
       , dockerFile: 'Dockerfile.test'
+      , dockerTags: 'latest,{major}-latest , fake, {version}'
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
       tt.match(config, {
         dockerfile: 'Dockerfile.test'
       , nocache: false
-      , tags: ['latest', '{major}-latest', '{version}']
+      , tags: ['latest', '{major}-latest', 'fake', '{version}']
       , args: {
           SRC_DIRECTORY: 'scoped'
         , TARGET_PATH: '.'

--- a/test/unit/lang/array.js
+++ b/test/unit/lang/array.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const {test, threw} = require('tap')
+const array = require('../../../lib/lang/array/index.js')
+
+test('array', async (t) => {
+  t.test('toArray', async (t) => {
+    const cases = [
+      {value: undefined, expected: [], message: 'toArray(undefined) == []'}
+    , {value: null, expected: [], message: 'toArray(null) == []'}
+    , {value: 1, expected: [1], message: 'toArray(1) == [1]'}
+    , {value: '', expected: [], message: 'toArray(\'\') == []'}
+    , {value: 'test', expected: ['test']}
+    , {value: '1,2,3', expected: ['1', '2', '3']}
+    , {value: '1, 2, 3', expected: ['1', '2', '3']}
+    , {value: '1, 2, 3', expected: ['1', ' 2', ' 3'], sep: ','}
+    , {value: '1|2|3', expected: ['1', '2', '3'], sep: '|'}
+    , {value: [1, 2, 3], expected: [1, 2, 3]}
+    , {value: new Set([1, null, 'test']), expected: [1, null, 'test']}
+    ]
+    for (const current of cases) {
+      const args = [current.value]
+      if (current.sep) {
+        args.push(current.sep)
+      }
+
+      t.deepEqual(
+        array.toArray(...args)
+      , current.expected
+      , current.message || `toArray(${current.value}) == ${current.expected}`
+      )
+    }
+  })
+}).catch(threw)


### PR DESCRIPTION
Parse tags array from string if not already an array. it is possible
for the tags array to actually be a string. In the case of being passed
from the command line tool `--dockerTags=x` yargs will only coerce to an
array if the flag is specified multiple times. This keeps the
functionality the same regaurdless of how it is passed