### PR TITLE
fix(config): ensure the docker context is passed image builds

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -19,6 +19,7 @@ async function buildConfig(build_id, config, context) {
   , dockerLogin: login = true
   , dockerImage: image
   , dockerPublish: publish = true
+  , dockerContext = '.'
   } = config
 
   let name = null
@@ -58,6 +59,6 @@ async function buildConfig(build_id, config, context) {
   , build: build_id
   , login: login
   , env: context.env
-  , context: config.context || '.'
+  , context: dockerContext
   }
 }

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -53,7 +53,7 @@ class Image {
   }
 
   get context() {
-    return this.opts.context
+    return path.resolve(this.opts.cwd, this.opts.context)
   }
 
   set context(ctx) {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -16,6 +16,7 @@ async function dockerPrepare(opts, context) {
   , dockerfile: opts.dockerfile
   , build_id: opts.build
   , cwd: cwd
+  , context: opts.context
   })
 
   const args = {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -15,6 +15,7 @@ async function publish(opts, context) {
   , dockerfile: opts.dockerfile
   , build_id: opts.build
   , cwd: cwd
+  , context: opts.context
   })
 
   const vars = buildTemplateVars(opts, context)

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -17,7 +17,8 @@ async function verify(opts, context) {
     const error = new SemanticError(
       'Docker image name not found'
     , 'EINVAL'
-    , 'Image name parsed from package.json name if possible. Or via the "image" option.'
+    , 'Image name parsed from package.json name if possible. '
+        + 'Or via the "dockerImage" option.'
     )
     throw error
   }
@@ -29,6 +30,7 @@ async function verify(opts, context) {
   , dockerfile: opts.dockerfile
   , build_id: opts.build
   , cwd: cwd
+  , context: opts.context
   })
 
   debug('docker options', opts)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,17 +2,18 @@ dependencies:
   '@semantic-release/error': 2.2.0
   debug: 4.1.1
   execa: 4.0.3
-  semantic-release: 17.1.1_semantic-release@17.1.1
+  semantic-release: 17.1.1
   semver: 7.3.2
 devDependencies:
-  '@esatterwhite/eslint-config-reasonable': 1.0.2_a25f33e4b977ea61acd8f11cbd787ca6
+  '@codedependant/release-config-npm': 1.0.3_semantic-release@17.1.1
   '@semantic-release/changelog': 5.0.1_semantic-release@17.1.1
   '@semantic-release/git': 9.0.0_semantic-release@17.1.1
   '@semantic-release/github': 7.0.7_semantic-release@17.1.1
   eslint: 7.5.0
+  eslint-config-codedependant: 2.1.6_eslint@7.5.0
   sinon: 9.0.2
   tap: 14.10.8
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.10.4:
     dependencies:
@@ -256,17 +257,23 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==
-  /@esatterwhite/eslint-config-reasonable/1.0.2_a25f33e4b977ea61acd8f11cbd787ca6:
+  /@codedependant/release-config-core/1.0.2_semantic-release@17.1.1:
     dependencies:
-      '@semantic-release/github': 7.0.7_semantic-release@17.1.1
-      eslint-plugin-node: 11.1.0_eslint@7.5.0
-      eslint-plugin-sensible: 2.2.0
+      '@semantic-release/changelog': 5.0.1_semantic-release@17.1.1
+      '@semantic-release/git': 9.0.0_semantic-release@17.1.1
     dev: true
     peerDependencies:
-      eslint: '*'
       semantic-release: '*'
     resolution:
-      integrity: sha512-G0Q9+QVdf3Nmk0cr2oX3JT8F7BzeoS4Y7zKpxSiaD/QvA0mFDWhcS7rkCJp424IDqvy1rMT+wwm/d6b0/8dXYQ==
+      integrity: sha512-q7MKrorZZMNTts0l/2REMeXRjNeJ6al1YZH3DrFnW9AW3Bgswg6iMONkAOD3POuhl8RuZCzcTcgJ7OtYjdxrTg==
+  /@codedependant/release-config-npm/1.0.3_semantic-release@17.1.1:
+    dependencies:
+      '@codedependant/release-config-core': 1.0.2_semantic-release@17.1.1
+    dev: true
+    peerDependencies:
+      semantic-release: '*'
+    resolution:
+      integrity: sha512-IuWNKticm7sSwhJKDzi1KjBCteAU1qEsLJyChJI+dn+YKkNr8NQf9Z9ot+BtEdL/eFs+1i6pReaXTYSzZo5oyg==
   /@nodelib/fs.scandir/2.1.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.3
@@ -374,7 +381,7 @@ packages:
       aggregate-error: 3.0.1
       fs-extra: 9.0.1
       lodash: 4.17.19
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
     dev: true
     engines:
       node: '>=10.18'
@@ -391,7 +398,8 @@ packages:
       import-from: 3.0.0
       lodash: 4.17.19
       micromatch: 4.0.2
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
+    dev: false
     engines:
       node: '>=10.18'
     peerDependencies:
@@ -411,7 +419,7 @@ packages:
       lodash: 4.17.19
       micromatch: 4.0.2
       p-reduce: 2.1.0
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
     dev: true
     engines:
       node: '>=10.18'
@@ -436,7 +444,7 @@ packages:
       mime: 2.4.6
       p-filter: 2.1.0
       p-retry: 4.2.0
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
       url-join: 4.0.1
     engines:
       node: '>=10.18'
@@ -457,9 +465,10 @@ packages:
       rc: 1.2.8
       read-pkg: 5.2.0
       registry-auth-token: 4.2.0
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
       semver: 7.3.2
       tempy: 0.5.0
+    dev: false
     engines:
       node: '>=10.18'
     peerDependencies:
@@ -478,7 +487,8 @@ packages:
       into-stream: 5.1.1
       lodash: 4.17.19
       read-pkg-up: 7.0.1
-      semantic-release: 17.1.1_semantic-release@17.1.1
+      semantic-release: 17.1.1
+    dev: false
     engines:
       node: '>=10.18'
     peerDependencies:
@@ -525,15 +535,18 @@ packages:
     resolution:
       integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
   /@types/minimist/1.2.0:
+    dev: false
     resolution:
       integrity: sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
   /@types/node/14.0.24:
     resolution:
       integrity: sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
   /@types/normalize-package-data/2.4.0:
+    dev: false
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
   /@types/parse-json/4.0.0:
+    dev: false
     resolution:
       integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
   /@types/retry/0.12.0:
@@ -543,6 +556,7 @@ packages:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+    dev: false
     hasBin: true
     resolution:
       integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
@@ -585,12 +599,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
-  /ansi-colors/3.2.3:
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
   /ansi-colors/4.1.1:
     dev: true
     engines:
@@ -600,6 +608,7 @@ packages:
   /ansi-escapes/4.3.1:
     dependencies:
       type-fest: 0.11.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -643,6 +652,7 @@ packages:
     resolution:
       integrity: sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   /ansicolors/0.3.2:
+    dev: false
     resolution:
       integrity: sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
   /anymatch/3.1.1:
@@ -677,9 +687,11 @@ packages:
     resolution:
       integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   /argv-formatter/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=
   /array-ify/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
   /array-union/2.1.0:
@@ -688,11 +700,13 @@ packages:
     resolution:
       integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
   /arrify/1.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
   /arrify/2.0.1:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -782,10 +796,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-  /browser-stdout/1.3.1:
-    dev: true
-    resolution:
-      integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
   /buffer-from/1.1.1:
     dev: true
     resolution:
@@ -833,6 +843,7 @@ packages:
       camelcase: 5.3.1
       map-obj: 4.1.0
       quick-lru: 4.0.1
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -843,6 +854,7 @@ packages:
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
   /camelcase/6.0.0:
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -851,6 +863,7 @@ packages:
     dependencies:
       ansicolors: 0.3.2
       redeyed: 2.1.1
+    dev: false
     hasBin: true
     resolution:
       integrity: sha1-fMEFXYItISlU0HsIXeolHMe8VQU=
@@ -875,22 +888,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  /chokidar/3.3.0:
-    dependencies:
-      anymatch: 3.1.1
-      braces: 3.0.2
-      glob-parent: 5.1.1
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.2.0
-    dev: true
-    engines:
-      node: '>= 8.10.0'
-    optionalDependencies:
-      fsevents: 2.1.3
-    resolution:
-      integrity: sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==
   /chokidar/3.4.1:
     dependencies:
       anymatch: 3.1.1
@@ -915,6 +912,7 @@ packages:
   /cli-table/0.3.1:
     dependencies:
       colors: 1.0.3
+    dev: false
     engines:
       node: '>= 0.2.0'
     resolution:
@@ -940,6 +938,7 @@ packages:
       string-width: 4.2.0
       strip-ansi: 6.0.0
       wrap-ansi: 6.2.0
+    dev: false
     resolution:
       integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   /code-point-at/1.1.0:
@@ -972,6 +971,7 @@ packages:
     resolution:
       integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
   /colors/1.0.3:
+    dev: false
     engines:
       node: '>=0.1.90'
     resolution:
@@ -992,6 +992,7 @@ packages:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 3.0.0
+    dev: false
     resolution:
       integrity: sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==
   /concat-map/0.0.1:
@@ -1002,6 +1003,7 @@ packages:
     dependencies:
       compare-func: 1.3.4
       q: 1.5.1
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -1018,6 +1020,7 @@ packages:
       semver: 6.3.0
       split: 1.0.1
       through2: 3.0.2
+    dev: false
     engines:
       node: '>=10'
     hasBin: true
@@ -1027,6 +1030,7 @@ packages:
     dependencies:
       lodash.ismatch: 4.4.0
       modify-values: 1.0.1
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -1040,6 +1044,7 @@ packages:
       split2: 2.2.0
       through2: 3.0.2
       trim-off-newlines: 1.0.1
+    dev: false
     engines:
       node: '>=10'
     hasBin: true
@@ -1061,6 +1066,7 @@ packages:
       parse-json: 5.0.0
       path-type: 4.0.0
       yaml: 1.10.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -1118,6 +1124,7 @@ packages:
     resolution:
       integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   /crypto-random-string/2.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -1131,14 +1138,9 @@ packages:
     resolution:
       integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   /dateformat/3.0.3:
+    dev: false
     resolution:
       integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-  /debug/3.2.6:
-    dependencies:
-      ms: 2.1.2
-    dev: true
-    resolution:
-      integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   /debug/4.1.1:
     dependencies:
       ms: 2.1.2
@@ -1148,6 +1150,7 @@ packages:
     dependencies:
       decamelize: 1.2.0
       map-obj: 1.0.1
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -1158,6 +1161,7 @@ packages:
     resolution:
       integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
   /deep-extend/0.6.0:
+    dev: false
     engines:
       node: '>=4.0.0'
     resolution:
@@ -1174,14 +1178,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
-  /define-properties/1.1.3:
-    dependencies:
-      object-keys: 1.1.1
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   /delayed-stream/1.0.0:
     dev: true
     engines:
@@ -1195,12 +1191,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-6/v2PC/6UTGcWPPetb9acL8foberUg/CtPdALeJUdD1B/weHNvzftoo00gYznqHGRhHEbykUGzqfG9RWOSr5yw==
-  /diff/3.5.0:
-    dev: true
-    engines:
-      node: '>=0.3.1'
-    resolution:
-      integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
   /diff/4.0.2:
     dev: true
     engines:
@@ -1225,6 +1215,7 @@ packages:
   /dot-prop/3.0.0:
     dependencies:
       is-obj: 1.0.1
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -1232,6 +1223,7 @@ packages:
   /duplexer2/0.1.4:
     dependencies:
       readable-stream: 2.3.7
+    dev: false
     resolution:
       integrity: sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   /ecc-jsbn/0.1.2:
@@ -1246,6 +1238,7 @@ packages:
     resolution:
       integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
   /emoji-regex/8.0.0:
+    dev: false
     resolution:
       integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
   /end-of-stream/1.4.4:
@@ -1265,6 +1258,7 @@ packages:
     dependencies:
       execa: 4.0.3
       java-properties: 1.0.2
+    dev: false
     engines:
       node: '>=10.13'
     resolution:
@@ -1274,34 +1268,6 @@ packages:
       is-arrayish: 0.2.1
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.17.6:
-    dependencies:
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.1
-      is-callable: 1.2.0
-      is-regex: 1.1.0
-      object-inspect: 1.8.0
-      object-keys: 1.1.1
-      object.assign: 4.1.0
-      string.prototype.trimend: 1.0.1
-      string.prototype.trimstart: 1.0.1
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
-  /es-to-primitive/1.2.1:
-    dependencies:
-      is-callable: 1.2.0
-      is-date-object: 1.0.2
-      is-symbol: 1.0.3
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   /es6-error/4.1.1:
     dev: true
     resolution:
@@ -1317,6 +1283,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+  /eslint-config-codedependant/2.1.6_eslint@7.5.0:
+    dependencies:
+      eslint: 7.5.0
+      eslint-plugin-node: 11.1.0_eslint@7.5.0
+      eslint-plugin-sensible: 2.3.1
+    dev: true
+    peerDependencies:
+      eslint: '>= 6'
+    resolution:
+      integrity: sha512-UBQeSPbGVp0cFl9MFY5/RIafalbWTS15g6XumMBVkZyCL8PVxvXz8EeM4M4SGXanjBB3i7ZwLpIDU8m9VGQduA==
   /eslint-plugin-es/3.0.1_eslint@7.5.0:
     dependencies:
       eslint: 7.5.0
@@ -1345,14 +1321,13 @@ packages:
       eslint: '>=5.16.0'
     resolution:
       integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
-  /eslint-plugin-sensible/2.2.0:
+  /eslint-plugin-sensible/2.3.1:
     dependencies:
-      lodash: 4.17.19
-      mocha: 7.2.0
+      lodash: 4.17.21
       requireindex: 1.2.0
     dev: true
     resolution:
-      integrity: sha512-AOsdFZvodKSNtw6IfPC22OxO145ZUJmsUB7HSz7NDN49tgZa9V4QB8TAPX8QhZzW+5EGFmU9pxdEq3ivy1tA1w==
+      integrity: sha512-Aam5eM2KBwHk8chcLgjgSXvV1TUi3UCtSYazDph+WzJvCRzqp1Mu/3n6zHZLM32toKdtKihXxkqf6ij+D6tWCg==
   /eslint-scope/5.1.0:
     dependencies:
       esrecurse: 4.2.1
@@ -1550,6 +1525,7 @@ packages:
   /figures/2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -1557,6 +1533,7 @@ packages:
   /figures/3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -1589,6 +1566,7 @@ packages:
   /find-up/2.1.0:
     dependencies:
       locate-path: 2.0.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -1605,6 +1583,7 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -1612,6 +1591,7 @@ packages:
   /find-versions/3.2.0:
     dependencies:
       semver-regex: 2.0.0
+    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -1630,13 +1610,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  /flat/4.1.0:
-    dependencies:
-      is-buffer: 2.0.4
-    dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   /flatted/2.0.2:
     dev: true
     resolution:
@@ -1683,6 +1656,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.7
+    dev: false
     resolution:
       integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
   /fs-exists-cached/1.0.0:
@@ -1712,10 +1686,6 @@ packages:
       - darwin
     resolution:
       integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
-  /function-bind/1.1.1:
-    dev: true
-    resolution:
-      integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
   /function-loop/1.0.2:
     dev: true
     resolution:
@@ -1763,6 +1733,7 @@ packages:
       stream-combiner2: 1.1.1
       through2: 2.0.5
       traverse: 0.6.6
+    dev: false
     resolution:
       integrity: sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=
   /glob-parent/5.1.1:
@@ -1772,17 +1743,6 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
-  /glob/7.1.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-    resolution:
-      integrity: sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   /glob/7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -1823,18 +1783,13 @@ packages:
   /graceful-fs/4.2.4:
     resolution:
       integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-  /growl/1.10.5:
-    dev: true
-    engines:
-      node: '>=4.x'
-    resolution:
-      integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
   /handlebars/4.7.6:
     dependencies:
       minimist: 1.2.5
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
+    dev: false
     engines:
       node: '>=0.4.7'
     hasBin: true
@@ -1858,6 +1813,7 @@ packages:
     resolution:
       integrity: sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   /hard-rejection/2.1.0:
+    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -1872,20 +1828,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-  /has-symbols/1.0.1:
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
-  /has/1.0.3:
-    dependencies:
-      function-bind: 1.1.1
-    dev: true
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   /hasha/3.0.0:
     dependencies:
       is-stream: 1.1.0
@@ -1894,12 +1836,8 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
-  /he/1.2.0:
-    dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
   /hook-std/2.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -1910,6 +1848,7 @@ packages:
   /hosted-git-info/3.0.5:
     dependencies:
       lru-cache: 6.0.0
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -1973,6 +1912,7 @@ packages:
   /import-from/3.0.0:
     dependencies:
       resolve-from: 5.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2012,12 +1952,14 @@ packages:
     resolution:
       integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
   /ini/1.3.5:
+    dev: false
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
   /into-stream/5.1.1:
     dependencies:
       from2: 2.3.0
       p-is-promise: 3.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2033,24 +1975,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  /is-buffer/2.0.4:
-    dev: true
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
-  /is-callable/1.2.0:
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
-  /is-date-object/1.0.2:
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
   /is-extglob/2.1.1:
     engines:
       node: '>=0.10.0'
@@ -2071,6 +1995,7 @@ packages:
     resolution:
       integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
   /is-fullwidth-code-point/3.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2088,11 +2013,13 @@ packages:
     resolution:
       integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
   /is-obj/1.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
   /is-plain-obj/1.1.0:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -2102,14 +2029,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-1N1OpoS8S4Ua+FsH6Mhvgaj0di3uRXgulcv2dnFu2J/WcEsDNbBoiUX6mYmhQ2cAzZ+B/lTJtX1qUSL5RwsGug==
-  /is-regex/1.1.0:
-    dependencies:
-      has-symbols: 1.0.1
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   /is-stream/1.1.0:
     engines:
       node: '>=0.10.0'
@@ -2120,17 +2039,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
-  /is-symbol/1.0.3:
-    dependencies:
-      has-symbols: 1.0.1
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   /is-text-path/1.0.1:
     dependencies:
       text-extensions: 1.9.0
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -2144,6 +2056,7 @@ packages:
     resolution:
       integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
   /isarray/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
   /isexe/2.0.0:
@@ -2241,6 +2154,7 @@ packages:
     resolution:
       integrity: sha512-VDcSunT+wcccoG46FtzuBAyQKlzhHjli4q31e1fIHGOsRspqNUFjVzGb+7eIFDlTvqLygxapDHPHS0ouT2o/tw==
   /java-properties/1.0.2:
+    dev: false
     engines:
       node: '>= 0.6.0'
     resolution:
@@ -2248,14 +2162,6 @@ packages:
   /js-tokens/4.0.0:
     resolution:
       integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-  /js-yaml/3.13.1:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-    dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   /js-yaml/3.14.0:
     dependencies:
       argparse: 1.0.10
@@ -2310,6 +2216,7 @@ packages:
     resolution:
       integrity: sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
   /jsonparse/1.3.1:
+    dev: false
     engines:
       '0': node >= 0.2.0
     resolution:
@@ -2330,6 +2237,7 @@ packages:
     resolution:
       integrity: sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
   /kind-of/6.0.3:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -2349,6 +2257,7 @@ packages:
     resolution:
       integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   /lines-and-columns/1.1.6:
+    dev: false
     resolution:
       integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
   /load-json-file/4.0.0:
@@ -2365,6 +2274,7 @@ packages:
     dependencies:
       p-locate: 2.0.0
       path-exists: 3.0.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -2381,6 +2291,7 @@ packages:
   /locate-path/5.0.0:
     dependencies:
       p-locate: 4.1.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2400,6 +2311,7 @@ packages:
     resolution:
       integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
   /lodash.ismatch/4.4.0:
+    dev: false
     resolution:
       integrity: sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
   /lodash.isplainobject/4.0.6:
@@ -2409,6 +2321,7 @@ packages:
     resolution:
       integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
   /lodash.toarray/4.4.0:
+    dev: false
     resolution:
       integrity: sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
   /lodash.uniqby/4.7.0:
@@ -2417,20 +2330,16 @@ packages:
   /lodash/4.17.19:
     resolution:
       integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  /lodash/4.17.21:
+    dev: true
+    resolution:
+      integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
   /log-driver/1.2.7:
     dev: true
     engines:
       node: '>=0.8.6'
     resolution:
       integrity: sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
-  /log-symbols/3.0.0:
-    dependencies:
-      chalk: 2.4.2
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   /loose-envify/1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2448,6 +2357,7 @@ packages:
   /lru-cache/6.0.0:
     dependencies:
       yallist: 4.0.0
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -2471,11 +2381,13 @@ packages:
     resolution:
       integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
   /map-obj/1.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
   /map-obj/4.1.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2489,11 +2401,13 @@ packages:
       marked: 1.1.1
       node-emoji: 1.10.0
       supports-hyperlinks: 2.1.0
+    dev: false
     peerDependencies:
       marked: '>=0.4.0 <2.0.0'
     resolution:
       integrity: sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==
   /marked/1.1.1:
+    dev: false
     engines:
       node: '>= 8.16.2'
     hasBin: true
@@ -2514,6 +2428,7 @@ packages:
       trim-newlines: 3.0.0
       type-fest: 0.13.1
       yargs-parser: 18.1.3
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -2566,6 +2481,7 @@ packages:
     resolution:
       integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
   /min-indent/1.0.1:
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -2581,6 +2497,7 @@ packages:
       arrify: 1.0.1
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
+    dev: false
     engines:
       node: '>= 6'
     resolution:
@@ -2603,47 +2520,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  /mocha/7.2.0:
-    dependencies:
-      ansi-colors: 3.2.3
-      browser-stdout: 1.3.1
-      chokidar: 3.3.0
-      debug: 3.2.6
-      diff: 3.5.0
-      escape-string-regexp: 1.0.5
-      find-up: 3.0.0
-      glob: 7.1.3
-      growl: 1.10.5
-      he: 1.2.0
-      js-yaml: 3.13.1
-      log-symbols: 3.0.0
-      minimatch: 3.0.4
-      mkdirp: 0.5.5
-      ms: 2.1.1
-      node-environment-flags: 1.0.6
-      object.assign: 4.1.0
-      strip-json-comments: 2.0.1
-      supports-color: 6.0.0
-      which: 1.3.1
-      wide-align: 1.1.3
-      yargs: 13.3.2
-      yargs-parser: 13.1.2
-      yargs-unparser: 1.6.0
-    dev: true
-    engines:
-      node: '>= 8.10.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==
   /modify-values/1.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-  /ms/2.1.1:
-    dev: true
-    resolution:
-      integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
   /ms/2.1.2:
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2652,9 +2534,11 @@ packages:
     resolution:
       integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
   /neo-async/2.6.2:
+    dev: false
     resolution:
       integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
   /nerf-dart/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=
   /nested-error-stacks/2.1.0:
@@ -2677,15 +2561,9 @@ packages:
   /node-emoji/1.10.0:
     dependencies:
       lodash.toarray: 4.4.0
+    dev: false
     resolution:
       integrity: sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
-  /node-environment-flags/1.0.6:
-    dependencies:
-      object.getownpropertydescriptors: 2.1.0
-      semver: 5.7.1
-    dev: true
-    resolution:
-      integrity: sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
   /node-fetch/2.6.0:
     engines:
       node: 4.x || >=6.0.0
@@ -2712,6 +2590,7 @@ packages:
     resolution:
       integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
   /normalize-url/5.0.0:
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -2855,6 +2734,7 @@ packages:
       - which
       - worker-farm
       - write-file-atomic
+    dev: false
     engines:
       node: 6 >=6.2.0 || 8 || >=9.3.0
     hasBin: true
@@ -2909,36 +2789,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-  /object-inspect/1.8.0:
-    dev: true
-    resolution:
-      integrity: sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-  /object-keys/1.1.1:
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-  /object.assign/4.1.0:
-    dependencies:
-      define-properties: 1.1.3
-      function-bind: 1.1.1
-      has-symbols: 1.0.1
-      object-keys: 1.1.1
-    dev: true
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
-  /object.getownpropertydescriptors/2.1.0:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.6
-    dev: true
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -2994,6 +2844,7 @@ packages:
     resolution:
       integrity: sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=
   /p-each-series/2.1.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3011,6 +2862,7 @@ packages:
     resolution:
       integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
   /p-is-promise/3.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3018,6 +2870,7 @@ packages:
   /p-limit/1.3.0:
     dependencies:
       p-try: 1.0.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -3032,6 +2885,7 @@ packages:
   /p-locate/2.0.0:
     dependencies:
       p-limit: 1.3.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -3047,6 +2901,7 @@ packages:
   /p-locate/4.1.0:
     dependencies:
       p-limit: 2.3.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3070,6 +2925,7 @@ packages:
     resolution:
       integrity: sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==
   /p-try/1.0.0:
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -3111,6 +2967,7 @@ packages:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
       lines-and-columns: 1.1.6
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3121,6 +2978,7 @@ packages:
     resolution:
       integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
   /path-exists/4.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3195,6 +3053,7 @@ packages:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -3214,6 +3073,7 @@ packages:
     resolution:
       integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
   /process-nextick-args/2.0.1:
+    dev: false
     resolution:
       integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
   /progress/2.0.3:
@@ -3251,6 +3111,7 @@ packages:
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /q/1.5.1:
+    dev: false
     engines:
       node: '>=0.6.0'
       teleport: '>=0.2.0'
@@ -3263,6 +3124,7 @@ packages:
     resolution:
       integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
   /quick-lru/4.0.1:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3273,6 +3135,7 @@ packages:
       ini: 1.3.5
       minimist: 1.2.5
       strip-json-comments: 2.0.1
+    dev: false
     hasBin: true
     resolution:
       integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -3304,6 +3167,7 @@ packages:
       find-up: 4.1.0
       read-pkg: 5.2.0
       type-fest: 0.8.1
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3324,6 +3188,7 @@ packages:
       normalize-package-data: 2.5.0
       parse-json: 5.0.0
       type-fest: 0.6.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3337,6 +3202,7 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+    dev: false
     resolution:
       integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   /readable-stream/3.6.0:
@@ -3344,18 +3210,11 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    dev: false
     engines:
       node: '>= 6'
     resolution:
       integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  /readdirp/3.2.0:
-    dependencies:
-      picomatch: 2.2.2
-    dev: true
-    engines:
-      node: '>= 8'
-    resolution:
-      integrity: sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
   /readdirp/3.4.0:
     dependencies:
       picomatch: 2.2.2
@@ -3368,6 +3227,7 @@ packages:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3375,6 +3235,7 @@ packages:
   /redeyed/2.1.1:
     dependencies:
       esprima: 4.0.1
+    dev: false
     resolution:
       integrity: sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
   /regexpp/3.1.0:
@@ -3386,6 +3247,7 @@ packages:
   /registry-auth-token/4.2.0:
     dependencies:
       rc: 1.2.8
+    dev: false
     engines:
       node: '>=6.0.0'
     resolution:
@@ -3452,6 +3314,7 @@ packages:
     resolution:
       integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
   /resolve-from/5.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3499,7 +3362,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-  /semantic-release/17.1.1_semantic-release@17.1.1:
+  /semantic-release/17.1.1:
     dependencies:
       '@semantic-release/commit-analyzer': 8.0.1_semantic-release@17.1.1
       '@semantic-release/error': 2.2.0
@@ -3529,21 +3392,22 @@ packages:
       semver-diff: 3.1.1
       signale: 1.4.0
       yargs: 15.4.1
+    dev: false
     engines:
       node: '>=10.18'
     hasBin: true
-    peerDependencies:
-      semantic-release: '*'
     resolution:
       integrity: sha512-9H+207eynBJElrQBHySZm+sIEoJeUhPA2zU4cdlY1QSInd2lnE8GRD2ALry9EassE22c9WW+aCREwBhro5AIIg==
   /semver-diff/3.1.1:
     dependencies:
       semver: 6.3.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
   /semver-regex/2.0.0:
+    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -3597,6 +3461,7 @@ packages:
       chalk: 2.4.2
       figures: 2.0.0
       pkg-conf: 2.1.0
+    dev: false
     engines:
       node: '>=6'
     resolution:
@@ -3647,6 +3512,7 @@ packages:
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
   /spawn-error-forwarder/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=
   /spawn-wrap/1.4.3:
@@ -3681,16 +3547,19 @@ packages:
   /split/1.0.1:
     dependencies:
       through: 2.3.8
+    dev: false
     resolution:
       integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   /split2/1.0.0:
     dependencies:
       through2: 2.0.5
+    dev: false
     resolution:
       integrity: sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=
   /split2/2.2.0:
     dependencies:
       through2: 2.0.5
+    dev: false
     resolution:
       integrity: sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   /sprintf-js/1.0.3:
@@ -3724,6 +3593,7 @@ packages:
     dependencies:
       duplexer2: 0.1.4
       readable-stream: 2.3.7
+    dev: false
     resolution:
       integrity: sha1-+02KFCDqNidk4hrUeAOXvry0HL4=
   /string-width/1.0.2:
@@ -3760,32 +3630,21 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  /string.prototype.trimend/1.0.1:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.6
-    dev: true
-    resolution:
-      integrity: sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
-  /string.prototype.trimstart/1.0.1:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.6
-    dev: true
-    resolution:
-      integrity: sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
+    dev: false
     resolution:
       integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   /string_decoder/1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    dev: false
     resolution:
       integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   /strip-ansi/3.0.1:
@@ -3837,11 +3696,13 @@ packages:
   /strip-indent/3.0.0:
     dependencies:
       min-indent: 1.0.1
+    dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
   /strip-json-comments/2.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -3859,14 +3720,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  /supports-color/6.0.0:
-    dependencies:
-      has-flag: 3.0.0
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==
   /supports-color/6.1.0:
     dependencies:
       has-flag: 3.0.0
@@ -3886,6 +3739,7 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.1.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3993,6 +3847,7 @@ packages:
     resolution:
       integrity: sha512-Q3TitMVK59NyKgQyFh+857wTAUE329IzLDehuPgU4nF5e8g+EUQ+yUbjUy1/6ugiNnXztphT+NnqlCXolv9P3A==
   /temp-dir/2.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -4003,6 +3858,7 @@ packages:
       temp-dir: 2.0.0
       type-fest: 0.12.0
       unique-string: 2.0.0
+    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -4019,6 +3875,7 @@ packages:
     resolution:
       integrity: sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
   /text-extensions/1.9.0:
+    dev: false
     engines:
       node: '>=0.10'
     resolution:
@@ -4028,18 +3885,21 @@ packages:
     resolution:
       integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
   /through/2.3.8:
+    dev: false
     resolution:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
   /through2/2.0.5:
     dependencies:
       readable-stream: 2.3.7
       xtend: 4.0.2
+    dev: false
     resolution:
       integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   /through2/3.0.2:
     dependencies:
       inherits: 2.0.4
       readable-stream: 3.6.0
+    dev: false
     resolution:
       integrity: sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==
   /to-fast-properties/2.0.0:
@@ -4065,14 +3925,17 @@ packages:
     resolution:
       integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   /traverse/0.6.6:
+    dev: false
     resolution:
       integrity: sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
   /trim-newlines/3.0.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
   /trim-off-newlines/1.0.1:
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -4122,21 +3985,25 @@ packages:
     resolution:
       integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
   /type-fest/0.11.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
   /type-fest/0.12.0:
+    dev: false
     engines:
       node: '>=10'
     resolution:
       integrity: sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
   /type-fest/0.13.1:
+    dev: false
     engines:
       node: '>=10'
     resolution:
       integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
   /type-fest/0.6.0:
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -4160,6 +4027,7 @@ packages:
     resolution:
       integrity: sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
   /uglify-js/3.10.0:
+    dev: false
     engines:
       node: '>=0.8.0'
     hasBin: true
@@ -4176,6 +4044,7 @@ packages:
   /unique-string/2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -4203,6 +4072,7 @@ packages:
     resolution:
       integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
   /util-deprecate/1.0.2:
+    dev: false
     resolution:
       integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
   /uuid/3.4.0:
@@ -4251,12 +4121,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  /wide-align/1.1.3:
-    dependencies:
-      string-width: 2.1.1
-    dev: true
-    resolution:
-      integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   /windows-release/3.3.1:
     dependencies:
       execa: 1.0.0
@@ -4271,6 +4135,7 @@ packages:
     resolution:
       integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
   /wordwrap/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
   /wrap-ansi/2.1.0:
@@ -4297,6 +4162,7 @@ packages:
       ansi-styles: 4.2.1
       string-width: 4.2.0
       strip-ansi: 6.0.0
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -4330,6 +4196,7 @@ packages:
     resolution:
       integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   /xtend/4.0.2:
+    dev: false
     engines:
       node: '>=0.4'
     resolution:
@@ -4364,20 +4231,11 @@ packages:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+    dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  /yargs-unparser/1.6.0:
-    dependencies:
-      flat: 4.1.0
-      lodash: 4.17.19
-      yargs: 13.3.2
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==
   /yargs/13.3.2:
     dependencies:
       cliui: 5.0.0
@@ -4406,6 +4264,7 @@ packages:
       which-module: 2.0.0
       y18n: 4.0.0
       yargs-parser: 18.1.3
+    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -4417,13 +4276,14 @@ packages:
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 specifiers:
-  '@esatterwhite/eslint-config-reasonable': ^1.0.2
+  '@codedependant/release-config-npm': ^1.0.1
   '@semantic-release/changelog': ^5.0.1
   '@semantic-release/error': ^2.2.0
   '@semantic-release/git': ^9.0.0
   '@semantic-release/github': ^7.0.7
   debug: ^4.1.1
   eslint: ^7.4.0
+  eslint-config-codedependant: ^2.1.6
   execa: ^4.0.2
   semantic-release: ^17.1.1
   semver: ^7.3.2

--- a/test/integration/prepare.js
+++ b/test/integration/prepare.js
@@ -49,6 +49,7 @@ test('steps::prepare', async (t) => {
       , BUILD_DATE: '{now}'
       }
     , dockerFile: 'docker/Dockerfile.prepare'
+    , dockerContext: 'docker'
     }, context)
 
     const auth = await verify(config, context)
@@ -64,6 +65,7 @@ test('steps::prepare', async (t) => {
     tt.equal(image.opts.args.get('MAJOR_TEMPLATE'), '2', 'MAJOR_TEMPLATE value')
     tt.equal(image.opts.args.get('GIT_REF'), 'abacadaba', 'GIT_REF value')
     tt.match(image.opts.args.get('BUILD_DATE'), DATE_REGEX, 'BUILD_DATE value')
+    tt.equal(image.context, path.join(context.cwd, config.context), 'docker context path')
 
     const {stdout} = await execa('docker', [
       'images', image.name

--- a/test/integration/verify.js
+++ b/test/integration/verify.js
@@ -172,7 +172,8 @@ test('steps::verify', async (t) => {
       code: 'EINVAL'
     , name: 'SemanticReleaseError'
     , details: new RegExp(
-        'image name parsed from package.json name if possible. or via the "image" option'
+        'image name parsed from package.json name if possible. '
+          + 'or via the "dockerImage" option'
       , 'gi'
       )
     })

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -60,7 +60,7 @@ test('Image', async (t) => {
     , args: Map
     }, 'default image options')
 
-    tt.equal(img.context, '.', 'default image context')
+    tt.equal(img.context, path.join(__dirname, 'build', '.'), 'default image context')
     img.context = __dirname
     tt.equal(img.context, __dirname, 'context override')
     tt.equal(
@@ -176,7 +176,7 @@ test('Image', async (t) => {
       , 'quay.io/esatterwhite/test:abacadaba'
       , '-f'
       , path.join(process.cwd(), 'Dockerfile')
-      , '.'
+      , process.cwd()
       ], 'build command')
     }
 
@@ -284,6 +284,20 @@ test('Image', async (t) => {
     , '-q', '--format={{ .Tag }}'
     ])
     tt.deepEqual(stdout, '', 'all tags removed')
+  })
+
+  t.test('image.context', async (tt) => {
+    const img = new docker.Image({
+      name: 'test'
+    , registry: 'quay.io'
+    , project: 'esatterwhite'
+    , build_id: build_id
+    , cwd: __dirname
+    , dockerfile: path.join('fixture', 'Dockerfile.test')
+    , context: 'fixture'
+    })
+
+    tt.equal(img.context, path.join(__dirname, 'fixture'), 'expected image context')
   })
 
 }).catch(threw)


### PR DESCRIPTION
The `dockerContext` options was documented but never implemented making
it always utilize the default value of `.` or cwd. update steps to pass
the context which the docker Image class will resolve against the
current working directory

Fixes: #13