### PR TITLE
feat: adds dockerTarget argument to build the image for a specific stage in the Docker container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ module.exports = {
         API_TOKEN: true
       , RELEASE_DATE: new Date().toISOString()
       , RELEASE_VERSION: '{next.version}'
-      }
+      },
+      dockerTarget: 'my-target-stage'
     }]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ omitted, it is assumed the docker daemon is already authenticated with the targe
 | `dockerLogin`         | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                 | `true`                                                        |
 | `dockerArgs`          | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                         |                                                               |
 | `dockerPublish`       | _Optional_. Automatically push image tags during the publish phase.                                                                         | `true`                                                        |
+| `dockerTarget`        | _Optional_. Set the target build stage to build.                                                                                            | `null`                                                        |
 
 ### Build Arguments
 

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -20,6 +20,7 @@ async function buildConfig(build_id, config, context) {
   , dockerImage: image
   , dockerPublish: publish = true
   , dockerContext = '.'
+  , dockerTarget = null
   } = config
 
   let name = null
@@ -60,5 +61,6 @@ async function buildConfig(build_id, config, context) {
   , login: login
   , env: context.env
   , context: dockerContext
+  , target: dockerTarget,
   }
 }

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -15,6 +15,7 @@ class Image {
     , dockerfile = 'Dockerfile'
     , cwd = process.cwd()
     , context = '.'
+    , target = null
     } = opts || {}
 
     if (!name || typeof name !== 'string') {
@@ -32,6 +33,7 @@ class Image {
     , dockerfile: dockerfile
     , context: context
     , cwd: cwd
+    , target: target
     }
   }
 
@@ -79,6 +81,9 @@ class Image {
         args.push('--build-arg', `${name}=${value}`)
       }
     }
+    if (this.opts.target !== null) {
+      args.push('--target', this.opts.target)
+    }
     const cmd = [
       'build'
     , '--quiet'
@@ -93,7 +98,13 @@ class Image {
   }
 
   async build() {
-    const stream = execa('docker', this.build_cmd)
+    const env = {}
+    // Setting a stage as target requires buildkit to be enabled
+    if (this.opts.target !== null) {
+      env.DOCKER_BUILDKIT = 1
+    }
+
+    const stream = execa("docker", this.build_cmd, { env });
     stream.stdout.pipe(process.stdout)
     stream.stderr.pipe(process.stderr)
     const {stdout} = await stream

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -17,6 +17,7 @@ async function dockerPrepare(opts, context) {
   , build_id: opts.build
   , cwd: cwd
   , context: opts.context
+  , target: opts.target
   })
 
   const args = {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -16,6 +16,7 @@ async function publish(opts, context) {
   , build_id: opts.build
   , cwd: cwd
   , context: opts.context
+  , target: opts.target
   })
 
   const vars = buildTemplateVars(opts, context)

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -31,6 +31,7 @@ async function verify(opts, context) {
   , build_id: opts.build
   , cwd: cwd
   , context: opts.context
+  , target: opts.target
   })
 
   debug('docker options', opts)


### PR DESCRIPTION
This PR adds support for specifying the `--target` option in the Docker build command through a new option `dockerTarget`. Using this option it becomes possible to build a Docker image from a specific stage in [multi-stage Dockerfiles](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds).

My use-case for this feature is a situation where we have a multi-stage Dockerfile with a production and a test stage. We would like to release and publish separate images for both of the stages.

The changes introduced with this PR are intended to be fully backwards compatible, as omitting the newly introduced argument will not alter the original behavior of this plugin. 

When setting the newly provided `dockerTarget` argument, it will default to enabling build kit through the `DOCKER_BUILDKIT` environment variable on the `docker build`-command. Without this behavior it has been observed in practice (e.g. in a GitHub Actions runner) that BuildKit is disabled and then the `--target` option isn't available, causing the build to fail. 

We've already started using the fork and there it all works fine in workflows using the plugin twice: once with the `dockerTarget` and once without the `dockerTarget`, which releases the two Docker container images described in the use-case above. So the changes have been verified to work fine for us 😄 . 

---

For reference, this is the help text for the `--target`-option in the `docker build` help text.
```
 --target string           Set the target build stage to build.
```