### PR TITLE
feat(docker): allow command to be run via docker in verify step

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,18 @@ omitted, it is assumed the docker daemon is already authenticated with the targe
 
 ### Options
 
-| Option                | Description                                                                                                                                 | Default
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------
-| `dockerTags`          | _Optional_. An array of strings allowing to specify additional tags to apply to the image. Supports templating                              | [`latest`, `{{major}}-latest`, `{{version}}`]                 |
-| `dockerImage`         | _Optional_. The name of the image to release.                                                                                               | Parsed from package.json `name` property                      |
-| `dockerRegistry`      | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port | `null` (dockerhub)                                            |
-| `dockerProject`       | _Optional_. The project or repository name to publish the image to                                                                          | For scoped packages, the scope will be used, otherwise `null` |
-| `dockerFile`          | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                    | `Dockerfile`                                                  |
-| `dockerContext`       | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                        | `.`                                                           |
-| `dockerLogin`         | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                 | `true`                                                        |
-| `dockerArgs`          | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                         |                                                               |
-| `dockerPublish`       | _Optional_. Automatically push image tags during the publish phase.                                                                         | `true`                                                        |
+| Option            | Description                                                                                                                                                            | Default                                                       |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `dockerTags`      | _Optional_. An array of strings allowing to specify additional tags to apply to the image. Supports templating                                                         | [`latest`, `{{major}}-latest`, `{{version}}`]                 |
+| `dockerImage`     | _Optional_. The name of the image to release.                                                                                                                          | Parsed from package.json `name` property                      |
+| `dockerRegistry`  | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port                            | `null` (dockerhub)                                            |
+| `dockerProject`   | _Optional_. The project or repository name to publish the image to                                                                                                     | For scoped packages, the scope will be used, otherwise `null` |
+| `dockerFile`      | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                                               | `Dockerfile`                                                  |
+| `dockerContext`   | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                                                   | `.`                                                           |
+| `dockerLogin`     | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                                            | `true`                                                        |
+| `dockerArgs`      | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                                                    |                                                               |
+| `dockerPublish`   | _Optional_. Automatically push image tags during the publish phase.                                                                                                    | `true`                                                        |
+| `dockerVerifyCmd` | _Optional_. If specified, during the verify stage, the specified command will execute in a container of the build image. If the command errors, the release will fail. | `false`                                                       |
 
 ### Build Arguments
 

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -20,6 +20,7 @@ async function buildConfig(build_id, config, context) {
   , dockerImage: image
   , dockerPublish: publish = true
   , dockerContext = '.'
+  , dockerVerifyCmd: verifycmd = null
   } = config
 
   let name = null
@@ -44,6 +45,7 @@ async function buildConfig(build_id, config, context) {
   , project
   , publish
   , tags: array.toArray(tags)
+  , verifycmd
   , args: {
       SRC_DIRECTORY: path.basename(context.cwd)
     , TARGET_PATH: target

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const crypto = require('crypto')
 const execa = require('execa')
+const array = require('../lang/array/index.js')
 
 class Image {
   constructor(opts) {
@@ -79,7 +80,7 @@ class Image {
         args.push('--build-arg', `${name}=${value}`)
       }
     }
-    const cmd = [
+    return [
       'build'
     , '--quiet'
     , '--tag'
@@ -89,7 +90,21 @@ class Image {
     , this.dockerfile
     , this.context
     ]
-    return cmd
+  }
+
+  async run(cmd) {
+    const stream = execa('docker', [
+      'run'
+    , '--rm'
+    , this.name
+    , ...array.toArray(cmd)
+    ], {all: true})
+
+    stream.stdout.pipe(process.stdout)
+    stream.stderr.pipe(process.stderr)
+
+    const {all} = await stream
+    return all
   }
 
   async build() {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -4,12 +4,13 @@ const {promises: fs} = require('fs')
 const execa = require('execa')
 const debug = require('debug')('semantic-release:semantic-release-docker:verify')
 const SemanticError = require('@semantic-release/error')
+const prepare = require('./prepare.js')
 const docker = require('./docker/index.js')
 
 module.exports = verify
 
 async function verify(opts, context) {
-  const {env, logger, cwd} = context
+  const {env, cwd} = context
   const PASSWORD = env.DOCKER_REGISTRY_PASSWORD || env.GITHUB_TOKEN
   const USERNAME = env.DOCKER_REGISTRY_USER
 
@@ -51,47 +52,59 @@ async function verify(opts, context) {
   debug('image to build', image.repo)
   if (!USERNAME && !PASSWORD) {
     debug('No docker credentials found.  Skipping login')
-    return false
+  } else {
+    await doLogin({...opts, USERNAME, PASSWORD}, context)
   }
+
+  if (!opts.verifycmd) return true
+
+  const img = await prepare(opts, context)
+  const output = await img.run(opts.verifycmd)
+  if (opts.dryRun) await img.clean()
+  return output
+}
+
+async function doLogin(opts, context) {
+  const {USERNAME, PASSWORD} = opts
+  const {logger} = context
 
   if (opts.login === false) {
     debug('docker login === false. Skipping login')
-    return false
+  } else {
+    let set = 0
+    if (USERNAME) set += 1
+    if (PASSWORD) set += 1
+
+    if (set !== 2) {
+      const error = new SemanticError(
+        'Docker authentication failed'
+      , 'EAUTH'
+      , 'Both ENV vars DOCKER_REGISTRY_USER and DOCKER_REGISTRY_PASSWORD must be set'
+      )
+      throw error
+    }
+
+    const passwd = execa('echo', [PASSWORD])
+    const login = execa('docker', [
+      'login'
+    , opts.registry || ''
+    , '-u', USERNAME
+    , '--password-stdin'
+    ])
+
+    passwd.stdout.pipe(login.stdin)
+
+    try {
+      await login
+    } catch (err) {
+      logger.fatal(err)
+      const error = new SemanticError(
+        'Docker authentication failed'
+      , 'EAUTH'
+      , `Authentication to ${opts.registry || 'dockerhub'} failed`
+      )
+      throw error
+    }
+    logger.success('docker login successful')
   }
-
-  let set = 0
-  if (USERNAME) set += 1
-  if (PASSWORD) set += 1
-
-  if (set !== 2) {
-    const error = new SemanticError(
-      'Docker authentication failed'
-    , 'EAUTH'
-    , 'Both ENV vars DOCKER_REGISTRY_USER and DOCKER_REGISTRY_PASSWORD must be set'
-    )
-    throw error
-  }
-
-  const passwd = execa('echo', [PASSWORD])
-  const login = execa('docker', [
-    'login'
-  , opts.registry || ''
-  , '-u', USERNAME
-  , '--password-stdin'
-  ])
-
-  passwd.stdout.pipe(login.stdin)
-
-  try {
-    await login
-  } catch (err) {
-    const error = new SemanticError(
-      'Docker authentication failed'
-    , 'EAUTH'
-    , `Authentication to ${opts.registry || 'dockerhub'} failed`
-    )
-    throw error
-  }
-  logger.success('docker login successful')
-  return true
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "url": "git+ssh://git@github.com/esatterwhite/semantic-release-docker.git"
   },
   "tap": {
-    "esm": false,
     "ts": false,
     "jsx": false,
     "timeout": 60,
@@ -54,6 +53,7 @@
       "text",
       "text-summary",
       "json",
+      "json-summary",
       "html"
     ],
     "nyc-arg": [

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "tap": "^14.10.7"
   },
   "dependencies": {
-    "@semantic-release/error": "^2.2.0",
+    "@semantic-release/error": "^3.0.0",
     "debug": "^4.1.1",
     "execa": "^4.0.2",
     "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-config-codedependant": "^3.0.0",
     "semantic-release": "17",
     "sinon": "^9.0.2",
-    "tap": "^14.10.7"
+    "tap": "^16.0.0"
   },
   "dependencies": {
     "@semantic-release/error": "^3.0.0",

--- a/test/integration/prepare.js
+++ b/test/integration/prepare.js
@@ -34,6 +34,7 @@ test('steps::prepare', async (t) => {
         success: sinon.stub()
       , info: sinon.stub()
       , debug: sinon.stub()
+      , fatal: sinon.stub()
       }
     }
 
@@ -41,6 +42,7 @@ test('steps::prepare', async (t) => {
       dockerRegistry: DOCKER_REGISTRY_HOST
     , dockerProject: 'docker-prepare'
     , dockerImage: 'fake'
+    , dockerVerifyCmd: ['date', '+\'%x\'']
     , dockerArgs: {
         MY_VARIABLE: '1'
       , TAG_TEMPLATE: '{{git_tag}}'
@@ -52,8 +54,11 @@ test('steps::prepare', async (t) => {
     , dockerContext: 'docker'
     }, context)
 
-    const auth = await verify(config, context)
-    tt.ok(auth, `authentication to ${DOCKER_REGISTRY_HOST} suceeds`)
+    tt.match(
+      await verify(config, context)
+    , /\d{2}\/\d{2}\/\d{2}/
+    , 'verify command executed'
+    )
 
     const image = await prepare(config, context)
 

--- a/test/integration/verify.js
+++ b/test/integration/verify.js
@@ -8,21 +8,29 @@ const buildConfig = require('../../lib/build-config.js')
 const verify = require('../../lib/verify.js')
 const DOCKER_REGISTRY_HOST = process.env.TEST_DOCKER_REGISTRY || 'localhost:5000'
 
+const logger = {
+  success: sinon.stub()
+, debug: sinon.stub()
+, info: sinon.stub()
+, fatal: sinon.stub()
+}
+
 test('steps::verify', async (t) => {
   const build_id = crypto.randomBytes(5).toString('hex')
   t.test('docker password, no username', async (tt) => {
     const context = {
       env: {
         ...process.env
+      , GITHUB_TOKEN: ''
       , DOCKER_REGISTRY_PASSWORD: 'abc123'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
-    const config = await buildConfig(build_id, {}, context)
+    const config = await buildConfig(build_id, {
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    }, context)
+
     await tt.rejects(
       verify(config, context)
     , {
@@ -33,20 +41,22 @@ test('steps::verify', async (t) => {
     )
   })
 
-  t.test('docker password, no username', async (tt) => {
+  t.test('docker username, no password', async (tt) => {
     const context = {
       env: {
         ...process.env
+      , GITHUB_TOKEN: ''
       , DOCKER_REGISTRY_USER: 'abc123'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
-    const config = await buildConfig(build_id, {}, context)
-    await tt.rejects(
+
+    const config = await buildConfig(build_id, {
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    }, context)
+
+    tt.rejects(
       verify(config, context)
     , {
         message: /docker authentication failed/i
@@ -64,14 +74,12 @@ test('steps::verify', async (t) => {
       , DOCKER_REGISTRY_PASSWORD: 'secretsquirrel'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
     const config = await buildConfig(build_id, {
       dockerRegistry: DOCKER_REGISTRY_HOST
     }, context)
+
     tt.resolves(verify(config, context))
   })
 
@@ -83,10 +91,7 @@ test('steps::verify', async (t) => {
       , GITHUB_TOKEN: 'secretsquirrel'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
     const config = await buildConfig(build_id, {
       dockerRegistry: DOCKER_REGISTRY_HOST
@@ -101,10 +106,7 @@ test('steps::verify', async (t) => {
       , DOCKER_REGISTRY_USER: 'iamweasel'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
     const config = await buildConfig(build_id, {
       dockerRegistry: DOCKER_REGISTRY_HOST
@@ -121,10 +123,7 @@ test('steps::verify', async (t) => {
       , DOCKER_REGISTRY_USER: 'abc123'
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
     const config = await buildConfig(build_id, {}, context)
     tt.rejects(
@@ -141,16 +140,14 @@ test('steps::verify', async (t) => {
     const context = {
       env: {
         ...process.env
+      , GITHUB_TOKEN: ''
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
 
     const config = await buildConfig(build_id, {}, context)
-    tt.strictEqual(await verify(config, context), false, 'auth step skipped')
+    tt.strictEqual(await verify(config, context), true, 'auth step skipped')
   })
 
   t.test('unable to collect image name', async (tt) => {
@@ -159,10 +156,7 @@ test('steps::verify', async (t) => {
         ...process.env
       }
     , cwd: __dirname
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
 
     const config = await buildConfig(build_id, {
@@ -185,10 +179,7 @@ test('steps::verify', async (t) => {
         ...process.env
       }
     , cwd: process.cwd()
-    , logger: {
-        success: sinon.stub()
-      , info: sinon.stub()
-      }
+    , logger: logger
     }
 
     const config = await buildConfig(build_id, {
@@ -201,6 +192,6 @@ test('steps::verify', async (t) => {
     , name: 'SemanticReleaseError'
     , details: /relative to pwd/gi
     })
-
   })
+
 }).catch(threw)


### PR DESCRIPTION
Expose a setting for a command to be run in the build image during the
verify stage. During a dry run, the prepare stage is never run, which is
the stage that actualy builds the image.

fixes: https://github.com/esatterwhite/semantic-release-docker/issues/20