### PR TITLE
feat(config): add option to disable post publish image removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,20 @@ omitted, it is assumed the docker daemon is already authenticated with the targe
 
 ### Options
 
-| Option            | Description                                                                                                                                                            | Default                                                       |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| `dockerTags`      | _Optional_. An array of strings allowing to specify additional tags to apply to the image. Supports templating                                                         | [`latest`, `{{major}}-latest`, `{{version}}`]                 |
-| `dockerImage`     | _Optional_. The name of the image to release.                                                                                                                          | Parsed from package.json `name` property                      |
-| `dockerRegistry`  | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port                            | `null` (dockerhub)                                            |
-| `dockerProject`   | _Optional_. The project or repository name to publish the image to                                                                                                     | For scoped packages, the scope will be used, otherwise `null` |
-| `dockerFile`      | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                                               | `Dockerfile`                                                  |
-| `dockerContext`   | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                                                   | `.`                                                           |
-| `dockerLogin`     | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                                            | `true`                                                        |
-| `dockerArgs`      | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                                                    |                                                               |
-| `dockerPublish`   | _Optional_. Automatically push image tags during the publish phase.                                                                                                    | `true`                                                        |
-| `dockerVerifyCmd` | _Optional_. If specified, during the verify stage, the specified command will execute in a container of the build image. If the command errors, the release will fail. | `false`                                                       |
-| `dockerNetwork`   | _Optional_. Specify the Docker network to use while the image is building.                                                                                             | `default`                                                     |
+| Option            | Description                                                                                                                                                            | Type                        | Default                                                       |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|---------------------------------------------------------------|
+| `dockerTags`      | _Optional_. An array of strings allowing to specify additional tags to apply to the image. Supports templating                                                         | [Array][]&lt;[String][]&gt; | [`latest`, `{{major}}-latest`, `{{version}}`]                 |
+| `dockerImage`     | _Optional_. The name of the image to release.                                                                                                                          | [String][]                  | Parsed from package.json `name` property                      |
+| `dockerRegistry`  | _Optional_. The hostname and port used by the the registry in format `hostname[:port]`. Omit the port if the registry uses the default port                            | [String][]                  | `null` (dockerhub)                                            |
+| `dockerProject`   | _Optional_. The project or repository name to publish the image to                                                                                                     | [String][]                  | For scoped packages, the scope will be used, otherwise `null` |
+| `dockerFile`      | _Optional_. The path, relative to `$PWD` to a Docker file to build the target image with                                                                               | [String][]                  | `Dockerfile`                                                  |
+| `dockerContext`   | _Optional_. A path, relative to `$PWD` to use as the build context A                                                                                                   | [String][]                  | `.`                                                           |
+| `dockerLogin`     | _Optional_. Set to false it by pass docker login if the docker daemon is already authorized                                                                            | [String][]                  | `true`                                                        |
+| `dockerArgs`      | _Optional_. Include additional values for docker's `build-arg`. Supports templating                                                                                    | [Object][]                  |                                                               |
+| `dockerPublish`   | _Optional_. Automatically push image tags during the publish phase.                                                                                                    | [Boolean][]                 | `true`                                                        |
+| `dockerVerifyCmd` | _Optional_. If specified, during the verify stage, the specified command will execute in a container of the build image. If the command errors, the release will fail. | [String][]                  | `false`                                                       |
+| `dockerNetwork`   | _Optional_. Specify the Docker network to use while the image is building.                                                                                             | [String][]                  | `default`                                                     |
+| `dockerAutoClean` | _Optional_. If set to true                                                                                                                                             | [Boolean][]                 | `true`                                                        |
 
 ### Build Arguments
 
@@ -79,22 +80,22 @@ secrets and other sensitive information
 
 String template will be passed these
 
-| Variable name  | Description                                                        | Type            |
-|----------------|--------------------------------------------------------------------|-----------------|
-| `git_sha`      | The commit SHA of the current release                              | `String`        |
-| `git_tag`      | The git tag of the current release                                 | `String`        |
-| `release_type` | The severity type of the current build (`major`, `minor`, `patch`) | `String`        |
-| `relase_notes` | The release notes blob associated with the release                 | `String`        |
-| `next`         | Semver object representing the next release                        | `Object`        |
-| `previous`     | Semver object representing the previous release                    | `Object`        |
-| `major`        | The major version of the next release                              | `Number`        |
-| `minor`        | The minor version of the next release                              | `Number`        |
-| `patch`        | The patch version of the next release                              | `Number`        |
-| `prerelease`   | The prerelease versions of the next release                        | `Array<Number>` |
-| `env`          | Environment variables that were set at build time                  | `Object`        |
-| `pkg`          | Values parsed from `package.json`                                  | `Object`        |
-| `build`        | A Random build hash representing the current execution context     | `String`        |
-| `now`          | Current timestamp is ISO 8601 format                               | `String`        |
+| Variable name  | Description                                                        | Type                        |
+|----------------|--------------------------------------------------------------------|-----------------------------|
+| `git_sha`      | The commit SHA of the current release                              | [String][]                  |
+| `git_tag`      | The git tag of the current release                                 | [String][]                  |
+| `release_type` | The severity type of the current build (`major`, `minor`, `patch`) | [String][]                  |
+| `relase_notes` | The release notes blob associated with the release                 | [String][]                  |
+| `next`         | Semver object representing the next release                        | [Object][]                  |
+| `previous`     | Semver object representing the previous release                    | [Object][]                  |
+| `major`        | The major version of the next release                              | [Number][]                  |
+| `minor`        | The minor version of the next release                              | [Number][]                  |
+| `patch`        | The patch version of the next release                              | [Number][]                  |
+| `prerelease`   | The prerelease versions of the next release                        | [Array][]&lt;[Number][]&gt; |
+| `env`          | Environment variables that were set at build time                  | [Object][]                  |
+| `pkg`          | Values parsed from `package.json`                                  | [Object][]                  |
+| `build`        | A Random build hash representing the current execution context     | [String][]                  |
+| `now`          | Current timestamp is ISO 8601 format                               | [String][]                  |
 
 ### Template Helpers
 
@@ -230,3 +231,5 @@ $ openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -o
 [Boolean]: https://mdn.io/boolean
 [String]: https://mdn.io/string
 [Array]: https://mdn.io/array
+[Object]: https://mdn.io/object
+[Number]: https://mdn.io/number

--- a/index.js
+++ b/index.js
@@ -5,13 +5,21 @@ const dockerPrepare = require('./lib/prepare.js')
 const dockerVerify = require('./lib/verify.js')
 const dockerPublish = require('./lib/publish.js')
 const buildConfig = require('./lib/build-config.js')
+const dockerSuccess = require('./lib/success.js')
+const dockerFail = require('./lib/fail.js')
 const build_id = crypto.randomBytes(10).toString('hex')
 
 module.exports = {
-  prepare
+  buildConfig
+, fail
+, prepare
 , publish
+, success
 , verifyConditions
-, buildConfig
+}
+
+async function fail(config, context) {
+  return dockerFail(await buildConfig(build_id, config, context), context)
 }
 
 async function prepare(config, context) {
@@ -22,7 +30,10 @@ async function publish(config, context) {
   return dockerPublish(await buildConfig(build_id, config, context), context)
 }
 
+async function success(config, context) {
+  return dockerSuccess(await buildConfig(build_id, config, context), context)
+}
+
 async function verifyConditions(config, context) {
   return dockerVerify(await buildConfig(build_id, config, context), context)
 }
-

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -5,6 +5,7 @@ const readPkg = require('./read-pkg.js')
 const object = require('./lang/object/index.js')
 const array = require('./lang/array/index.js')
 const parsePkgName = require('./parse-pkg-name.js')
+const typeCast = require('./lang/string/typecast.js')
 const PWD = '.'
 
 module.exports = buildConfig
@@ -22,6 +23,7 @@ async function buildConfig(build_id, config, context) {
   , dockerContext = '.'
   , dockerVerifyCmd: verifycmd = null
   , dockerNetwork: network = 'default'
+  , dockerAutoClean: clean = true
   } = config
 
   let name = null
@@ -64,5 +66,6 @@ async function buildConfig(build_id, config, context) {
   , env: context.env
   , context: dockerContext
   , network: network
+  , clean: typeCast(clean) === true
   }
 }

--- a/lib/fail.js
+++ b/lib/fail.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const postPublish = require('./post-publish.js')
+
+module.exports = fail
+
+function fail(opts, context) {
+  return postPublish(opts, context)
+}

--- a/lib/lang/string/index.js
+++ b/lib/lang/string/index.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   template: require('./template.js')
+, typecast: require('./typecast.js')
 }

--- a/lib/lang/string/typecast.js
+++ b/lib/lang/string/typecast.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * @module lib/string/typecast
+ * @author Eric Satterwhite
+ **/
+
+module.exports = function typecast(value) {
+  if (value === 'null' || value === null) return null
+  if (value === 'undefined' || value === undefined) return undefined
+  if (value === 'true' || value === true) return true
+  if (value === 'false' || value === false) return false
+  if (value === '' || isNaN(value)) return value
+  if (isFinite(value)) return parseFloat(value)
+  return value
+}
+
+/**
+ * Best effort to cast a string to its native couter part where possible
+ * Supported casts are booleans, numbers, null and undefined
+ * @function module:lib/string/typecast
+ * @param {String} str The string value to typecast
+ * @return {*} The coerced value
+ * @example
+ * typecast('null') // null
+ * @example
+ * typecast('true') // true
+ * @example
+ * typecast('10.01') // 10.01
+ * @example
+ * typecast({}) // {}
+ **/

--- a/lib/post-publish.js
+++ b/lib/post-publish.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const docker = require('./docker/index.js')
+
+module.exports = postPublish
+
+async function postPublish(opts, context) {
+  const {cwd, logger} = context
+  const image = new docker.Image({
+    registry: opts.registry
+  , project: opts.project
+  , name: opts.name
+  , dockerfile: opts.dockerfile
+  , build_id: opts.build
+  , cwd: cwd
+  , context: opts.context
+  })
+
+  if (!opts.clean) return
+
+  logger.info(`removing images for ${image.repo}`)
+  await image.clean()
+}

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -28,6 +28,4 @@ async function publish(opts, context) {
     logger.info(`pushing image: ${image.repo} tag: ${tag}`)
     await image.tag(tag, opts.publish)
   }
-
-  await image.clean()
 }

--- a/lib/success.js
+++ b/lib/success.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const postPublish = require('./post-publish.js')
+
+module.exports = success
+
+function success(opts, context) {
+  return postPublish(opts, context)
+}

--- a/test/fixture/docker/Dockerfile.post
+++ b/test/fixture/docker/Dockerfile.post
@@ -1,0 +1,4 @@
+FROM debian:buster-slim
+COPY . /opt/app
+WORKDIR /opt/app
+CMD ["echo", "$PWD"]

--- a/test/integration/post-publish.js
+++ b/test/integration/post-publish.js
@@ -1,0 +1,190 @@
+'use strict'
+
+const os = require('os')
+const crypto = require('crypto')
+const path = require('path')
+const sinon = require('sinon')
+const execa = require('execa')
+const {test, threw} = require('tap')
+const buildConfig = require('../../lib/build-config.js')
+const verify = require('../../lib/verify.js')
+const prepare = require('../../lib/prepare.js')
+const publish = require('../../lib/publish.js')
+const success = require('../../lib/success.js')
+const fail = require('../../lib/fail.js')
+const fixturedir = path.join(__dirname, '..', 'fixture')
+
+const DOCKER_REGISTRY_HOST = process.env.TEST_DOCKER_REGISTRY || 'localhost:5000'
+
+
+const logger = {
+  success: sinon.stub()
+, info: sinon.stub()
+, debug: sinon.stub()
+, fatal: sinon.stub()
+}
+test('post publish', async (t) => {
+  t.test('success', async (t) => {
+    const build_id = crypto.randomBytes(5).toString('hex')
+    const context = {
+      env: {
+        ...process.env
+      , DOCKER_REGISTRY_USER: 'iamweasel'
+      , DOCKER_REGISTRY_PASSWORD: 'secretsquirrel'
+      }
+    , cwd: fixturedir
+    , nextRelease: {version: '2.0.0'}
+    , lastRelease: {version: '1.5.0'}
+    , logger: logger
+    }
+
+    const opts = {
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerProject: `postpublish-${build_id}`
+    , dockerImage: 'success'
+    , dockerTags: ['{{major}}', '{{major}}.{{minor}}']
+    , dockerFile: 'docker/Dockerfile.post'
+    , dockerAutoClean: false
+    }
+
+    const config = await buildConfig(build_id, opts, context)
+    const auth = await verify(config, context)
+    t.ok(auth, `authentication to ${DOCKER_REGISTRY_HOST} suceeds`)
+
+    const image = await prepare(config, context)
+
+    await publish(config, context)
+
+    // remove build tag
+    await execa('docker', [
+      'rmi', image.name
+    ])
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+      const tags = stdout.split(os.EOL)
+
+      t.same(tags, ['2', '2.0'], 'expect tags exists before succes stage')
+    }
+
+
+    await success(config, context)
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+
+      t.same(
+        stdout.split(os.EOL).filter(Boolean)
+      , ['2', '2.0']
+      , 'autoClean=false does not remove local tags with')
+    }
+
+    await success(
+      await buildConfig(build_id, {
+        ...opts
+      , dockerAutoClean: true
+      }, context)
+    , context
+    )
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+
+      t.same(
+        stdout.split(os.EOL).filter(Boolean)
+      , []
+      , 'autoClean=true removes local tags with')
+    }
+  })
+
+  t.test('fail', async (t) => {
+    const build_id = crypto.randomBytes(5).toString('hex')
+    const context = {
+      env: {
+        ...process.env
+      , DOCKER_REGISTRY_USER: 'iamweasel'
+      , DOCKER_REGISTRY_PASSWORD: 'secretsquirrel'
+      }
+    , cwd: fixturedir
+    , nextRelease: {version: '3.0.0'}
+    , lastRelease: {version: '2.0.0'}
+    , logger: logger
+    }
+
+    const opts = {
+      dockerRegistry: DOCKER_REGISTRY_HOST
+    , dockerProject: `postpublish-${build_id}`
+    , dockerImage: 'fail'
+    , dockerTags: ['{{major}}', '{{major}}.{{minor}}']
+    , dockerFile: 'docker/Dockerfile.post'
+    , dockerAutoClean: false
+    }
+
+    const config = await buildConfig(build_id, opts, context)
+    const auth = await verify(config, context)
+    t.ok(auth, `authentication to ${DOCKER_REGISTRY_HOST} suceeds`)
+
+    const image = await prepare(config, context)
+
+    await publish(config, context)
+
+    // remove build tag
+    await execa('docker', [
+      'rmi', image.name
+    ])
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+      const tags = stdout.split(os.EOL)
+
+      t.same(tags, ['3', '3.0'], 'expect tags exists before succes stage')
+    }
+
+
+    await fail(config, context)
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+
+      t.same(
+        stdout.split(os.EOL).filter(Boolean)
+      , ['3', '3.0']
+      , 'autoClean=false does not remove local tags with')
+    }
+
+    await fail(
+      await buildConfig(build_id, {
+        ...opts
+      , dockerAutoClean: true
+      }, context)
+    , context
+    )
+
+    {
+      const {stdout} = await execa('docker', [
+        'images', image.repo
+      , '-q', '--format={{ .Tag }}'
+      ])
+
+      t.same(
+        stdout.split(os.EOL).filter(Boolean)
+      , []
+      , 'autoClean=true removes local tags with')
+    }
+  })
+}).catch(threw)

--- a/test/integration/publish.js
+++ b/test/integration/publish.js
@@ -43,12 +43,9 @@ test('steps::publish', async (t) => {
     tt.ok(auth, `authentication to ${DOCKER_REGISTRY_HOST} suceeds`)
 
     const image = await prepare(config, context)
-    tt.on('end', () => {
-      image.clean()
-    })
 
-    // removes images when done
     await publish(config, context)
+    await image.clean()
 
     const tags = ['1-previous', '2-foobar', '2.0.0']
     for (const tag of tags) {

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -43,6 +43,7 @@ test('build-config', async (t) => {
     , project: null
     , build: 'id'
     , context: '.'
+    , clean: true
     })
   })
 
@@ -73,6 +74,7 @@ test('build-config', async (t) => {
     , project: 'internal'
     , build: 'id'
     , context: '.'
+    , clean: true
     })
   })
 
@@ -100,6 +102,7 @@ test('build-config', async (t) => {
       , project: 'scope'
       , build: 'id'
       , context: '.'
+      , clean: true
       })
     }
 
@@ -131,6 +134,7 @@ test('build-config', async (t) => {
       , project: 'kittens'
       , build: 'id'
       , context: '.'
+      , clean: true
       })
     }
 
@@ -140,6 +144,7 @@ test('build-config', async (t) => {
       , dockerImage: 'override'
       , dockerFile: 'Dockerfile.test'
       , dockerTags: 'latest,{{major}}-latest , fake, {{version}}'
+      , dockerAutoClean: false
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
@@ -161,6 +166,7 @@ test('build-config', async (t) => {
       , project: null
       , build: 'id'
       , context: '.'
+      , clean: false
       })
     }
   })

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -171,7 +171,7 @@ test('Image', async (t) => {
       , build_id: 'abacadaba'
       })
 
-      tt.deepEqual(img.build_cmd, [
+      tt.same(img.build_cmd, [
         'build'
       , '--network=default'
       , '--quiet'
@@ -193,7 +193,7 @@ test('Image', async (t) => {
       , context: path.join(__dirname, 'fake')
       })
 
-      tt.deepEqual(img.build_cmd, [
+      tt.same(img.build_cmd, [
         'build'
       , '--network=default'
       , '--quiet'
@@ -217,7 +217,7 @@ test('Image', async (t) => {
 
       img.arg('ARG_1', 'yes')
       img.arg('VALUE_FROM_ENV', true)
-      tt.deepEqual(img.build_cmd, [
+      tt.same(img.build_cmd, [
         'build'
       , '--network=default'
       , '--quiet'
@@ -249,9 +249,14 @@ test('Image', async (t) => {
     const sha = await img.build()
     tt.equal(sha, img.sha, 'image sha set after build')
     const {stdout} = await execa('docker', ['run', '--rm', img.name, 'ls', '-1'])
-    tt.deepEqual(
+    tt.same(
       stdout.split(os.EOL).sort()
-    , ['Dockerfile.test', 'Dockerfile.publish', 'Dockerfile.prepare'].sort()
+    , [
+        'Dockerfile.test'
+      , 'Dockerfile.publish'
+      , 'Dockerfile.prepare'
+      , 'Dockerfile.post'
+      ].sort()
     , 'files in image context')
   })
 
@@ -271,7 +276,7 @@ test('Image', async (t) => {
     , '-q', '--format={{ .Tag }}'
     ])
     const tags = stdout.split(os.EOL)
-    tt.deepEqual(tags.sort(), [build_id, '1.0.0'].sort(), 'image tags')
+    tt.same(tags.sort(), [build_id, '1.0.0'].sort(), 'image tags')
   })
 
   t.test('image#clean()', async (tt) => {
@@ -288,7 +293,7 @@ test('Image', async (t) => {
       'images', img.repo
     , '-q', '--format={{ .Tag }}'
     ])
-    tt.deepEqual(stdout, '', 'all tags removed')
+    tt.same(stdout, '', 'all tags removed')
   })
 
   t.test('image.context', async (tt) => {

--- a/test/unit/lang/string.js
+++ b/test/unit/lang/string.js
@@ -4,7 +4,7 @@ const {test, threw} = require('tap')
 const string = require('../../../lib/lang/string/index.js')
 
 test('string', async (t) => {
-  t.test('template', async (tt) => {
+  t.test('template', async (t) => {
     const cases = [
       {
         input: 'hello {{value}}'
@@ -31,7 +31,69 @@ test('string', async (t) => {
 
     for (const tcase of cases) {
       const tpl = string.template(tcase.input)
-      tt.equal(tpl(tcase.values), tcase.expected, tcase.message)
+      t.equal(tpl(tcase.values), tcase.expected, tcase.message)
+    }
+  })
+
+  t.test('typecast', async (t) => {
+    t.type(string.typecast, 'function', 'typecast is a function')
+    t.same(string.typecast({x: 1}), {x: 1}, 'non string value')
+    const cases = [{
+      value: 'foo'
+    , expected: 'foo'
+    }, {
+      value: 'true'
+    , expected: true
+    }, {
+      value: 'false'
+    , expected: false
+    }, {
+      value: true
+    , expected: true
+    }, {
+      value: false
+    , expected: false
+    }, {
+    }, {
+      value: '123'
+    , expected: 123
+    , message: 'integer value'
+    }, {
+      value: '123.45'
+    , expected: 123.45
+    , message: 'float value'
+    }, {
+      value: 'null'
+    , expected: null
+    , message: 'null string value'
+    }, {
+      value: null
+    , expected: null
+    , message: 'null literal value'
+    }, {
+      value: 'undefined'
+    , expected: undefined
+    , message: 'undefined string value'
+    }, {
+      value: undefined
+    , expected: undefined
+    , message: 'undefined literal value'
+    }, {
+      value: ''
+    , expected: ''
+    , message: 'empty string value'
+    }, {
+      value: Infinity
+    , expected: Infinity
+    , message: 'Infinity returns input'
+    }]
+
+    for (const current of cases) {
+      t.equal(
+        string.typecast(current.value)
+      , current.expected
+      , current.message || `camelCase(${current.value}) == ${current.expected}`
+      )
     }
   })
 }).catch(threw)


### PR DESCRIPTION
adds a boolean option `dockerAutoClean` which, when set to true will remove the docker images produced by the build step. The hook is run during both the `success` and `fail` stages, so the default behavior which was run as a part of the publish stage should remain intact

Fixes: #28