### PR TITLE
feat(#40): Remove --quiet as default build flag

### DIFF
--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -129,7 +129,6 @@ class Image {
     return [
       'build'
     , `--network=${this.network}`
-    , '--quiet'
     , '--tag'
     , this.name
     , ...this.flags


### PR DESCRIPTION
Remove the `--quiet` flag from the default docker build flags (issue #40)