### PR TITLE
feat(config): allow --quiet flag to be configurable

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -26,6 +26,7 @@ async function buildConfig(build_id, config, context) {
   , dockerVerifyCmd: verifycmd = null
   , dockerNetwork: network = 'default'
   , dockerAutoClean: clean = true
+  , dockerBuildQuiet: quiet = true
   } = config
 
   let name = null
@@ -72,6 +73,7 @@ async function buildConfig(build_id, config, context) {
   , env: context.env
   , context: dockerContext
   , network: network
+  , quiet: typeCast(quiet) === true
   , clean: typeCast(clean) === true
   }
 }

--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -17,6 +17,7 @@ class Image {
     , cwd = process.cwd()
     , context = '.'
     , network = 'default'
+    , quiet = true
     } = opts || {}
 
     if (!name || typeof name !== 'string') {
@@ -37,6 +38,8 @@ class Image {
     , project: project
     , registry: registry
     }
+
+    if (quiet) this.flag('quiet', null)
   }
 
   get id() {
@@ -129,14 +132,13 @@ class Image {
     return [
       'build'
     , `--network=${this.network}`
-    , '--quiet'
     , '--tag'
     , this.name
     , ...this.flags
     , '-f'
     , this.dockerfile
     , this.context
-    ]
+    ].filter(Boolean)
   }
 
   async run(cmd) {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -18,6 +18,7 @@ async function dockerPrepare(opts, context) {
   , cwd: cwd
   , context: opts.context
   , network: opts.network
+  , quiet: opts.quiet
   })
 
   const vars = buildTemplateVars(opts, context)

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -16,6 +16,7 @@ async function publish(opts, context) {
   , build_id: opts.build
   , cwd: cwd
   , context: opts.context
+  , quiet: opts.quiet
   })
 
   const vars = buildTemplateVars(opts, context)

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -43,6 +43,7 @@ test('build-config', async (t) => {
     , project: null
     , build: 'id'
     , context: '.'
+    , quiet: true
     , clean: true
     })
   })
@@ -74,6 +75,7 @@ test('build-config', async (t) => {
     , project: 'internal'
     , build: 'id'
     , context: '.'
+    , quiet: true
     , clean: true
     })
   })
@@ -103,6 +105,7 @@ test('build-config', async (t) => {
       , build: 'id'
       , context: '.'
       , clean: true
+      , quiet: true
       })
     }
 
@@ -112,6 +115,7 @@ test('build-config', async (t) => {
       , dockerImage: 'override'
       , dockerFile: 'Dockerfile.test'
       , dockerPublish: false
+      , dockerBuildQuiet: 'false'
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
@@ -135,6 +139,7 @@ test('build-config', async (t) => {
       , build: 'id'
       , context: '.'
       , clean: true
+      , quiet: false
       })
     }
 
@@ -145,6 +150,7 @@ test('build-config', async (t) => {
       , dockerFile: 'Dockerfile.test'
       , dockerTags: 'latest,{{major}}-latest , fake, {{version}}'
       , dockerAutoClean: false
+      , dockerBuildQuiet: 'false'
       }, {
         cwd: path.join(t.testdirName, 'scoped')
       })
@@ -166,6 +172,7 @@ test('build-config', async (t) => {
       , project: null
       , build: 'id'
       , context: '.'
+      , quiet: false
       , clean: false
       })
     }

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -176,9 +176,9 @@ test('Image', async (t) => {
       tt.same(img.build_cmd, [
         'build'
       , '--network=default'
-      , '--quiet'
       , '--tag'
       , 'quay.io/esatterwhite/test:abacadaba'
+      , '--quiet'
       , '-f'
       , path.join(process.cwd(), 'Dockerfile')
       , process.cwd()
@@ -198,9 +198,9 @@ test('Image', async (t) => {
       tt.same(img.build_cmd, [
         'build'
       , '--network=default'
-      , '--quiet'
       , '--tag'
       , 'us.gcr.io/esatterwhite/foobar:1010101'
+      , '--quiet'
       , '-f'
       , path.join(__dirname, 'Dockerfile')
       , path.join(__dirname, 'fake')
@@ -222,9 +222,9 @@ test('Image', async (t) => {
       tt.same(img.build_cmd, [
         'build'
       , '--network=default'
-      , '--quiet'
       , '--tag'
       , 'us.gcr.io/esatterwhite/foobar:1010101'
+      , '--quiet'
       , '--build-arg'
       , 'ARG_1=yes'
       , '--build-arg'
@@ -233,6 +233,33 @@ test('Image', async (t) => {
       , path.join(__dirname, 'Dockerfile')
       , path.join(__dirname, 'fake')
       ], 'build command')
+    }
+    {
+      const img = new docker.Image({
+        name: 'foobar'
+      , registry: 'us.gcr.io'
+      , project: 'esatterwhite'
+      , build_id: '1010101'
+      , cwd: __dirname
+      , context: path.join(__dirname, 'fake')
+      , quiet: false
+      })
+
+      img.arg('ARG_2', 'no')
+      img.arg('VALUE_FROM_ENV', true)
+      tt.same(img.build_cmd, [
+        'build'
+      , '--network=default'
+      , '--tag'
+      , 'us.gcr.io/esatterwhite/foobar:1010101'
+      , '--build-arg'
+      , 'ARG_2=no'
+      , '--build-arg'
+      , 'VALUE_FROM_ENV'
+      , '-f'
+      , path.join(__dirname, 'Dockerfile')
+      , path.join(__dirname, 'fake')
+      ], 'build command - quiet = false')
     }
   })
 


### PR DESCRIPTION
adds a new top level option `dockerBuildQuiet` which allows the toggle for the quiet flag in the docker build command

Fixes: #40