### PR TITLE
docs(README.md): fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ String template will be passed these
 | `git_sha`      | The commit SHA of the current release                              | [String][]                  |
 | `git_tag`      | The git tag of the current release                                 | [String][]                  |
 | `release_type` | The severity type of the current build (`major`, `minor`, `patch`) | [String][]                  |
-| `relase_notes` | The release notes blob associated with the release                 | [String][]                  |
+| `release_notes`| The release notes blob associated with the release                 | [String][]                  |
 | `next`         | Semver object representing the next release                        | [Object][]                  |
 | `previous`     | Semver object representing the previous release                    | [Object][]                  |
 | `major`        | The major version of the next release                              | [Number][]                  |


### PR DESCRIPTION
Fixes a typo in the README.md

I couldn't easily find this variable's use within the project - so may want to check that this is in-fact a typo and that the in-code variable doesn't also need to be updated.