### PR TITLE
fix(config): include the dry-run param from input options

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -28,6 +28,7 @@ async function buildConfig(build_id, config, context) {
   , dockerNetwork: network = 'default'
   , dockerAutoClean: clean = true
   , dockerBuildQuiet: quiet = true
+  , dryRun: dry_run = false
   } = config
 
   let name = null
@@ -57,6 +58,7 @@ async function buildConfig(build_id, config, context) {
   , publish
   , tags: array.toArray(tags)
   , verifycmd
+  , dry_run
   , args: {
       SRC_DIRECTORY: path.basename(context.cwd)
     , TARGET_PATH: target

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -45,11 +45,13 @@ test('build-config', async (t) => {
     , context: '.'
     , quiet: true
     , clean: true
+    , dry_run: false
     })
   })
 
   t.test('nested workspace: target resolution', async (tt) => {
     const config = await buildConfig('id', {
+      dryRun: true
     }, {
       options: {
         root: t.testdirName
@@ -77,6 +79,7 @@ test('build-config', async (t) => {
     , build: 'id'
     , context: '.'
     , quiet: true
+    , dry_run: true
     , clean: true
     })
   })


### PR DESCRIPTION
be sure to include the dry-run flag from semantic release if provided. default to false