### PR TITLE
fix(config): propgate dry run option to docker image

### DIFF
--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -87,7 +87,7 @@ class Image {
     , quiet: opts.quiet
     , publish: opts.publish
     , platform: opts.platform
-    , dry_run: !!opts.dryRun
+    , dry_run: !!opts.dry_run
     })
     for (const [key, value] of Object.entries(opts.args)) {
       image.arg(key, string.template(value)(vars))


### PR DESCRIPTION
The dry run flag was not being carried into the docker image setup in the from static method. this cause the verify command to fail in unexpected ways