### PR TITLE
fix(docker)!: specify an output type during buildx dry run

### DIFF
--- a/lib/docker/image.js
+++ b/lib/docker/image.js
@@ -203,6 +203,7 @@ class Image {
     this.flag('pull', null)
     if (this.opts.dry_run || !this.opts.publish) {
       this.opts.flags.delete('push')
+      this.flag('output', 'type=cacheonly')
     } else {
       this.flag('push', null)
     }

--- a/test/integration/release.js
+++ b/test/integration/release.js
@@ -98,6 +98,7 @@ test('buildx release', async (t) => {
     , version: '0.0.0-development'
     , scripts: {
         'test-release': 'semantic-release --dry-run'
+      , 'full-release': 'semantic-release'
       }
     , release: {
         ci: true
@@ -106,7 +107,7 @@ test('buildx release', async (t) => {
       , dockerRegistry: DOCKER_REGISTRY_HOST
       , dockerProject: 'docker-release'
       , dockerImage: 'fake'
-      , dockerVerifyBuild: true
+      , dockerVerifyCmd: ['ls']
       , dockerArgs: {
           SAMPLE_THING: '{{type}}.{{version}}'
         , GIT_REF: '{{git_sha}}-{{git_tag}}'
@@ -174,4 +175,39 @@ test('buildx release', async (t) => {
   stream.stdout.pipe(process.stdout)
   await stream
 
+  t.test('full release', async () => {
+    {
+      const stream = execa('npm', [
+        'install'
+      ], {
+        cwd: cwd
+      , env: {
+          BRANCH_NAME: 'main'
+        , CI_BRANCH: 'main'
+        , CI: 'true'
+        , GITHUB_REF: 'refs/heads/main'
+        }
+      })
+
+      stream.stdout.pipe(process.stdout)
+      await stream
+    }
+
+    const stream = execa('npm', [
+      'run'
+    , 'full-release'
+    , `--repositoryUrl=${origin}`], {
+      cwd: cwd
+    , env: {
+        BRANCH_NAME: 'main'
+      , CI_BRANCH: 'main'
+      , CI: 'true'
+      , GITHUB_REF: 'refs/heads/main'
+      , DOCKER_REGISTRY_USER: 'iamweasel'
+      , DOCKER_REGISTRY_PASSWORD: 'secretsquirrel'
+      }
+    })
+    stream.stdout.pipe(process.stdout)
+    await stream
+  })
 }).catch(threw)

--- a/test/unit/docker/image.js
+++ b/test/unit/docker/image.js
@@ -351,6 +351,8 @@ test('Image', async (t) => {
       , '--platform'
       , 'linux/amd64'
       , '--pull'
+      , '--output'
+      , 'type=cacheonly'
       , '-f'
       , path.join(__dirname, 'Dockerfile')
       , path.join(__dirname, 'fake')


### PR DESCRIPTION
recent versions of docker require an output type. to maintain backward compatibility, the image will specify --output type=cacheonly to stay inline with what was happening before, in that images were not stored on the local docker instance

BREAKING CHANGE: buildx dry-run will specifiy --output type=cacheonly